### PR TITLE
Absolute exit spread

### DIFF
--- a/application.example.yaml
+++ b/application.example.yaml
@@ -54,11 +54,14 @@ notifications:
 
 trading:
   # The percentage difference between the "long" and "short" exchanges before we will open our positions.
-  entrySpread: 0.0080
+  # Fees are added to this amount
+  # Increasing this value will make trades harder to enter
+  entrySpread: 0.0019
 
-  # The percentage difference *in profit only* before we will close our positions.
-  # Fees will be added to this amount.
-  exitTarget: 0.0050
+  # The percentage difference between the "long" and "short" exchanges before we will open our positions.
+  # Fees are added to this amount.
+  # Increasing this value will make trades easier to exit. The minimum profit percentage is entrySpread-exitSpread.
+  exitSpread: 0.0018
 
   # (Default: false)
   # Log notifications when a spreadIn reaches an all time high, or a spreadOut reaches an all time low.

--- a/src/main/java/com/r307/arbitrader/config/TradingConfiguration.java
+++ b/src/main/java/com/r307/arbitrader/config/TradingConfiguration.java
@@ -18,7 +18,7 @@ import static com.r307.arbitrader.DecimalConstants.USD_SCALE;
 @Configuration
 public class TradingConfiguration {
     private BigDecimal entrySpread;
-    private BigDecimal exitTarget;
+    private BigDecimal exitSpread;
     private Boolean spreadNotifications = false;
     private BigDecimal fixedExposure;
     private List<ExchangeConfiguration> exchanges = new ArrayList<>();
@@ -34,12 +34,12 @@ public class TradingConfiguration {
         this.entrySpread = entrySpread;
     }
 
-    public BigDecimal getExitTarget() {
-        return exitTarget;
+    public BigDecimal getExitSpread() {
+        return exitSpread;
     }
 
-    public void setExitTarget(BigDecimal exitTarget) {
-        this.exitTarget = exitTarget;
+    public void setExitSpread(BigDecimal exitSpread) {
+        this.exitSpread = exitSpread;
     }
 
     public Boolean isSpreadNotifications() {

--- a/src/main/java/com/r307/arbitrader/service/SpreadService.java
+++ b/src/main/java/com/r307/arbitrader/service/SpreadService.java
@@ -148,7 +148,7 @@ public class SpreadService {
 
     /**
      * Computes the "effective price" for a sell which is the price including exchange fees.
-     * The formula is: effective = price * (1 + fee)
+     * The formula is: effective = price * (1 - fee)
      * @param price The original price
      * @param fee The fee as a percentage, eg. 0.0025 for 0.25%
      * @return The price adjusted for fees

--- a/src/main/java/com/r307/arbitrader/service/TradingService.java
+++ b/src/main/java/com/r307/arbitrader/service/TradingService.java
@@ -246,7 +246,7 @@ public class TradingService {
 
             if (profit.compareTo(BigDecimal.ZERO) <= 0) {
                 LOGGER.warn("Trade is not expected to be profitable. Tuck and roll!");
-                //return;
+                return;
             } else {
                 LOGGER.info("Trade looks good. Let's GOOOOO!!!");
             }

--- a/src/main/java/com/r307/arbitrader/service/TradingService.java
+++ b/src/main/java/com/r307/arbitrader/service/TradingService.java
@@ -152,7 +152,7 @@ public class TradingService {
         final BigDecimal shortFeePercent = exchangeService.getExchangeFee(spread.getShortExchange(), spread.getCurrencyPair(), true);
         final CurrencyPair currencyPairLongExchange = exchangeService.convertExchangePair(spread.getLongExchange(), spread.getCurrencyPair());
         final CurrencyPair currencyPairShortExchange = exchangeService.convertExchangePair(spread.getShortExchange(), spread.getCurrencyPair());
-        final BigDecimal exitTarget = spread.getIn().subtract(tradingConfiguration.getExitTarget()); // TODO should we drop the subtract so it's absolute instead of relative?
+        final BigDecimal exitTarget = tradingConfiguration.getExitSpread();
         final BigDecimal maxExposure = getMaximumExposure(spread.getLongExchange(), spread.getShortExchange());
 
         // check whether we have enough money to trade (forcing it can't work if we can't afford it)
@@ -246,7 +246,7 @@ public class TradingService {
 
             if (profit.compareTo(BigDecimal.ZERO) <= 0) {
                 LOGGER.warn("Trade is not expected to be profitable. Tuck and roll!");
-                return;
+                //return;
             } else {
                 LOGGER.info("Trade looks good. Let's GOOOOO!!!");
             }


### PR DESCRIPTION
Replace a relative exitTarget by an absolute exitSpread. The exitSpread is matched against an effective spread (including fees and slip), so both slip and fees are taken into account before closing the trade.