### PR TITLE
Enhance paper AccountInfo with balance info + paper trading FeeComputation.CLIENT

### DIFF
--- a/application.example.yaml
+++ b/application.example.yaml
@@ -102,7 +102,7 @@ trading:
     autoFill: true
 
     #The default initial cash balance of the paper trading exchanges, default is 100
-    #initialBalance: 100
+    initialBalance: 100
 
   # Connection information for each exchange goes in this list.
   #

--- a/application.example.yaml
+++ b/application.example.yaml
@@ -90,15 +90,19 @@ trading:
 
   # (Optional)
   # Enable paper trading. Orders will not be forwarded to the exchanges. Instead, a paper exchange will execute the
-  # order at the limit price. The paper exchange start with a cash balance of 100.
+  # order at the limit price.
   #
   # Set active to true to turn on paper trading (default) or false to trade real money.
-  #
-  # Enable the autoFill option to fill the trigger the order completion after 1s: useful to avoid waiting for the good
-  # market condition. If false, the paper exchange will wait for the limit price to be met by the real exchange.
+
   paper:
     active: true
+
+    # Enable the autoFill option to fill the trigger the order completion after 1s: useful to avoid waiting for the good
+    # market condition. If false, the paper exchange will wait for the limit price to be met by the real exchange.
     autoFill: true
+
+    #The default initial cash balance of the paper trading exchanges, default is 100
+    #initialBalance: 100
 
   # Connection information for each exchange goes in this list.
   #

--- a/src/main/java/com/r307/arbitrader/config/PaperConfiguration.java
+++ b/src/main/java/com/r307/arbitrader/config/PaperConfiguration.java
@@ -1,11 +1,14 @@
 package com.r307.arbitrader.config;
 
+import java.math.BigDecimal;
+
 /**
  * Configuration that governs the application's paper trading
  */
 public class PaperConfiguration {
     private Boolean active = true;
     private Boolean autoFill = false;
+    private BigDecimal initialBalance = new BigDecimal(100);
 
     public Boolean isActive() {
         return active;
@@ -21,5 +24,13 @@ public class PaperConfiguration {
 
     public void setAutoFill(Boolean autoFill) {
         this.autoFill = autoFill;
+    }
+
+    public BigDecimal getInitialBalance() {
+        return initialBalance;
+    }
+
+    public void setInitialBalance(BigDecimal initialBalance) {
+        this.initialBalance = initialBalance;
     }
 }

--- a/src/main/java/com/r307/arbitrader/service/paper/PaperAccountService.java
+++ b/src/main/java/com/r307/arbitrader/service/paper/PaperAccountService.java
@@ -1,5 +1,6 @@
 package com.r307.arbitrader.service.paper;
 
+import com.r307.arbitrader.config.PaperConfiguration;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.account.*;
@@ -14,42 +15,54 @@ import org.knowm.xchange.service.trade.params.WithdrawFundsParams;
 
 import java.io.IOException;
 import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
+import java.util.stream.Collectors;
 
 public class PaperAccountService implements AccountService {
 
     private final AccountService accountService;
     private final Currency homeCurrency;
 
-    private BigDecimal balance;
+    private Map<Currency, BigDecimal> balances;
 
-    public PaperAccountService (AccountService accountService, Currency homeCurrency, BigDecimal initialBalance) {
+    public PaperAccountService (AccountService accountService, Currency homeCurrency, PaperConfiguration paper) {
         this.accountService=accountService;
         this.homeCurrency=homeCurrency;
-        this.balance=initialBalance;
+        this.balances=new HashMap<>();
+        BigDecimal initialBalance = paper.getInitialBalance() != null ? paper.getInitialBalance() : new BigDecimal("100");
+        putCoin(homeCurrency,initialBalance);
     }
 
-    BigDecimal getBalance() {
-        return balance;
+    public Map<Currency, BigDecimal> getBalances() {
+        return balances;
     }
 
-    void setBalance(BigDecimal value) {
-        balance = value;
+    public BigDecimal getBalance(Currency currency) {
+        if(balances.containsKey(currency))
+            return balances.get(currency);
+        return BigDecimal.ZERO;
+    }
+
+    public void putCoin(Currency currency, BigDecimal amount) {
+        if(amount.compareTo(BigDecimal.ZERO) == 0) {
+            //DO NOTHING
+        } if(!balances.containsKey(currency)) {
+            balances.put(currency, amount);
+        } else if (getBalance(currency).compareTo(BigDecimal.ZERO) != 0){
+            balances.put(currency,getBalance(currency).add(amount));
+        } else {
+            balances.remove(currency);
+        }
     }
 
     public AccountInfo getAccountInfo() {
         List<Wallet> wallets = new ArrayList<>();
-        List<Balance> balances = new ArrayList<>();
-        balances.add(
-            new Balance(
-                this.homeCurrency,
-                this.balance,
-                this.balance,
-                new BigDecimal(0)));
-        wallets.add(Wallet.Builder.from(balances).id(UUID.randomUUID().toString()).build());
+        List<Balance> walletBalances = this.balances.entrySet().stream().map(entry -> new Balance(
+            entry.getKey(),
+            entry.getValue(),
+            entry.getValue(),
+            new BigDecimal(0))).collect(Collectors.toList());
+        wallets.add(Wallet.Builder.from(walletBalances).id(UUID.randomUUID().toString()).build());
         return new AccountInfo (wallets);
     }
 

--- a/src/main/java/com/r307/arbitrader/service/paper/PaperExchange.java
+++ b/src/main/java/com/r307/arbitrader/service/paper/PaperExchange.java
@@ -15,7 +15,6 @@ import org.knowm.xchange.service.trade.TradeService;
 import si.mazi.rescu.SynchronizedValueFactory;
 
 import java.io.IOException;
-import java.math.BigDecimal;
 import java.util.List;
 
 public class PaperExchange implements Exchange {
@@ -27,14 +26,14 @@ public class PaperExchange implements Exchange {
     public PaperExchange(Exchange exchange, Currency homeCurrency, TickerService tickerService, ExchangeService exchangeService, PaperConfiguration paper) {
         this.realExchange =exchange;
         this.tradeService=new PaperTradeService(this, exchange.getTradeService(), tickerService, exchangeService, paper);
-        this.accountService=new PaperAccountService(exchange.getAccountService(),homeCurrency, paper);
+        this.accountService=new PaperAccountService(this, exchange.getAccountService(),homeCurrency, exchangeService, paper);
     }
 
-    PaperTradeService getPaperTradeService() {
+    public PaperTradeService getPaperTradeService() {
         return tradeService;
     }
 
-    PaperAccountService getPaperAccountService() {
+    public PaperAccountService getPaperAccountService() {
         return accountService;
     }
 

--- a/src/main/java/com/r307/arbitrader/service/paper/PaperExchange.java
+++ b/src/main/java/com/r307/arbitrader/service/paper/PaperExchange.java
@@ -27,7 +27,11 @@ public class PaperExchange implements Exchange {
     public PaperExchange(Exchange exchange, Currency homeCurrency, TickerService tickerService, ExchangeService exchangeService, PaperConfiguration paper) {
         this.realExchange =exchange;
         this.tradeService=new PaperTradeService(this, exchange.getTradeService(), tickerService, exchangeService, paper);
-        this.accountService=new PaperAccountService(exchange.getAccountService(),homeCurrency, new BigDecimal(100));
+        this.accountService=new PaperAccountService(exchange.getAccountService(),homeCurrency, paper);
+    }
+
+    PaperTradeService getPaperTradeService() {
+        return tradeService;
     }
 
     PaperAccountService getPaperAccountService() {

--- a/src/main/java/com/r307/arbitrader/service/paper/PaperStreamExchange.java
+++ b/src/main/java/com/r307/arbitrader/service/paper/PaperStreamExchange.java
@@ -32,7 +32,7 @@ public class PaperStreamExchange extends PaperExchange implements StreamingExcha
         this.realExchange = realExchange;
 
         this.tradeService = new PaperTradeService(this, realExchange.getTradeService(), tickerService, exchangeService, paperConfiguration);
-        this.accountService = new PaperAccountService(realExchange.getAccountService(), homeCurrency, new BigDecimal(100));
+        this.accountService = new PaperAccountService(realExchange.getAccountService(), homeCurrency, paperConfiguration);
 
         this.marketDataService = realExchange.getMarketDataService();
 

--- a/src/main/java/com/r307/arbitrader/service/paper/PaperStreamExchange.java
+++ b/src/main/java/com/r307/arbitrader/service/paper/PaperStreamExchange.java
@@ -12,30 +12,17 @@ import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.meta.ExchangeMetaData;
 import org.knowm.xchange.exceptions.ExchangeException;
-import org.knowm.xchange.service.account.AccountService;
-import org.knowm.xchange.service.marketdata.MarketDataService;
-import org.knowm.xchange.service.trade.TradeService;
 import si.mazi.rescu.SynchronizedValueFactory;
 
 import java.io.IOException;
-import java.math.BigDecimal;
 import java.util.List;
 
 public class PaperStreamExchange extends PaperExchange implements StreamingExchange {
     private final StreamingExchange realExchange;
-    private final PaperTradeService tradeService;
-    private final PaperAccountService accountService;
-    private final MarketDataService marketDataService;
 
     public PaperStreamExchange(StreamingExchange realExchange, Currency homeCurrency, TickerService tickerService, ExchangeService exchangeService, PaperConfiguration paperConfiguration) {
         super(realExchange, homeCurrency, tickerService, exchangeService, paperConfiguration);
         this.realExchange = realExchange;
-
-        this.tradeService = new PaperTradeService(this, realExchange.getTradeService(), tickerService, exchangeService, paperConfiguration);
-        this.accountService = new PaperAccountService(realExchange.getAccountService(), homeCurrency, paperConfiguration);
-
-        this.marketDataService = realExchange.getMarketDataService();
-
     }
 
     @Override
@@ -91,21 +78,6 @@ public class PaperStreamExchange extends PaperExchange implements StreamingExcha
     @Override
     public void applySpecification(ExchangeSpecification exchangeSpecification) {
         realExchange.applySpecification(exchangeSpecification);
-    }
-
-    @Override
-    public MarketDataService getMarketDataService() {
-        return marketDataService;
-    }
-
-    @Override
-    public TradeService getTradeService() {
-        return tradeService;
-    }
-
-    @Override
-    public AccountService getAccountService() {
-        return accountService;
     }
 
     @Override

--- a/src/main/java/com/r307/arbitrader/service/paper/PaperTradeService.java
+++ b/src/main/java/com/r307/arbitrader/service/paper/PaperTradeService.java
@@ -11,6 +11,8 @@ import org.knowm.xchange.dto.account.AccountInfo;
 import org.knowm.xchange.dto.marketdata.Ticker;
 import org.knowm.xchange.dto.marketdata.Trades;
 import org.knowm.xchange.dto.trade.*;
+import org.knowm.xchange.exceptions.FundsExceededException;
+import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.trade.TradeService;
 import org.knowm.xchange.service.trade.params.TradeHistoryParams;
@@ -28,15 +30,15 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static com.r307.arbitrader.DecimalConstants.BTC_SCALE;
-import static com.r307.arbitrader.config.FeeComputation.CLIENT;
+import static com.r307.arbitrader.DecimalConstants.USD_SCALE;
 import static com.r307.arbitrader.config.FeeComputation.SERVER;
 import static org.knowm.xchange.dto.Order.OrderType.ASK;
 
 public class PaperTradeService extends BaseExchangeService<PaperExchange> implements TradeService {
     private static final Logger LOGGER = LoggerFactory.getLogger(PaperTradeService.class);
-    private static final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(2);
 
     private final boolean autoFill;
+
     private final TickerService tickerService;
     private final ExchangeService exchangeService;
     private final TradeService tradeService;
@@ -49,11 +51,15 @@ public class PaperTradeService extends BaseExchangeService<PaperExchange> implem
         this.autoFill = paper.isAutoFill();
         this.tickerService=tickerService;
         this.exchangeService=exchangeService;
-        PaperTradeService.scheduler.schedule(this::updateOrders,10, TimeUnit.SECONDS);
+        new Timer().scheduleAtFixedRate(new TimerTask() {
+            @Override
+            public void run() {
+                PaperTradeService.this.updateOrders();
+            }
+        }, 0, 2000);
     }
 
     public OpenOrders getOpenOrders() {
-        updateOrders();
         return new OpenOrders(orders.stream().filter(order -> order.getStatus().isOpen()).collect(Collectors.toList()));
     }
 
@@ -62,12 +68,12 @@ public class PaperTradeService extends BaseExchangeService<PaperExchange> implem
     }
 
     public String placeLimitOrder(LimitOrder limitOrder) {
-        updateOrders();
-        LimitOrder limit = new LimitOrder.Builder(limitOrder.getType(), limitOrder.getInstrument())
+        //Check if the order would keep our balance positive (for non margin accounts)
+        checkBalance(limitOrder);
+
+        LimitOrder limit = LimitOrder.Builder.from(limitOrder)
             .id(UUID.randomUUID().toString())
-            .originalAmount(limitOrder.getOriginalAmount())
             .timestamp(new Date())
-            .limitPrice(limitOrder.getLimitPrice())
             .orderStatus(Order.OrderStatus.NEW)
             .build();
 
@@ -84,7 +90,6 @@ public class PaperTradeService extends BaseExchangeService<PaperExchange> implem
     }
 
     public boolean cancelOrder(String orderId) {
-        updateOrders();
         Optional<Order> optionalOrder = getOrder(orderId).stream().findFirst();
         if(!optionalOrder.isPresent()) {
             LOGGER.warn("{} paper exchange: order {} to cancel not found.",
@@ -115,15 +120,14 @@ public class PaperTradeService extends BaseExchangeService<PaperExchange> implem
     }
 
     public void verifyOrder(LimitOrder limitOrder) {
-        //DO NOTHING
+        //TODO implement minimum amount and stepSize verification
     }
 
     public void verifyOrder(MarketOrder marketOrder) {
-        //DO NOTHING
+        throw new NotYetImplementedForExchangeException("Market orders are not supported by paper trading exchanges.");
     }
 
     public Collection<Order> getOrder(String... orderIds) {
-        updateOrders();
         if(orderIds == null || orderIds.length==0)
             return new ArrayList<>();
         return orders.stream().filter(order -> Arrays.asList(orderIds).contains(order.getId())).collect(Collectors.toList());
@@ -135,7 +139,9 @@ public class PaperTradeService extends BaseExchangeService<PaperExchange> implem
         return getOrder(orderIds.toArray(orderIdsArray));
     }
 
-
+    /**
+     * Update all the open orders according to real market data
+     */
     private void updateOrders() {
         for(LimitOrder order: orders) {
             if(order.getStatus().isOpen()) {
@@ -158,36 +164,31 @@ public class PaperTradeService extends BaseExchangeService<PaperExchange> implem
         }
     }
 
-
+    /**
+     * Fill an order at an averagePrice
+     * @param order the order to fill
+     * @param averagePrice the average price to fill the order at
+     */
     void fillOrder(LimitOrder order, BigDecimal averagePrice) {
-        FeeComputation feeComputation = exchangeService.getExchangeMetadata(exchange).getFeeComputation();
+        checkBalance(order, averagePrice);
 
         //Fill the order at the average price
         order.setOrderStatus(Order.OrderStatus.FILLED);
         order.setAveragePrice(averagePrice);
         order.setCumulativeAmount(order.getOriginalAmount());
 
-        BigDecimal feePercentage = exchangeService.getExchangeFee(exchange, order.getCurrencyPair(), false);
-        //Calculate fees in fiat currency
-        BigDecimal counterFee = feeComputation == SERVER ? order.getCumulativeCounterAmount().multiply(feePercentage) : BigDecimal.ZERO;
         //LimitOrder object cannot store the fees in crypto, only the fees in fiat
-        order.setFee(counterFee);
+        order.setFee(getCounterFee(order));
 
-        //Calculate fees in crypto currency
-        BigDecimal feeFactor = order.getType() == ASK ? BigDecimal.ONE.subtract(feePercentage) : BigDecimal.ONE.add(feePercentage);
-        BigDecimal baseFee = feeComputation == SERVER ? BigDecimal.ZERO : order.getCumulativeAmount().multiply(feePercentage).divide(feeFactor, BTC_SCALE, RoundingMode.HALF_EVEN);
+        //Find the total cost of the order
+        BigDecimal counterDelta = getCounterDelta(order);
+
+        //Find the total volume of the order
+        BigDecimal baseDelta = getBaseDelta(order);
 
         LOGGER.info("{} paper exchange: filled {}",
             exchange.getExchangeSpecification().getExchangeName(),
             order.toString());
-
-        //Find the total cost of the order
-        BigDecimal counterDelta = order.getType()== ASK ? order.getCumulativeCounterAmount(): order.getCumulativeCounterAmount().negate();
-        counterDelta = counterDelta.subtract(counterFee);
-
-        //Find the total volume of the order
-        BigDecimal baseDelta = order.getType()== ASK ? order.getCumulativeAmount().negate(): order.getCumulativeAmount();
-        baseDelta = baseDelta.subtract(baseFee);
 
         //Update balances
         exchange.getPaperAccountService().putCoin(order.getCurrencyPair().counter, counterDelta);
@@ -210,4 +211,75 @@ public class PaperTradeService extends BaseExchangeService<PaperExchange> implem
             order.getUserReference()));
     }
 
+    /**
+     * Check if the account as enough fund to pass the order if filled with this averagePrice.
+     * @see #checkBalance(LimitOrder) 
+     * @param order the order to check against the funds
+     * @param averagePrice the price to fill the order at      
+     */
+    private void checkBalance(LimitOrder order, BigDecimal averagePrice) {
+        checkBalance(LimitOrder.Builder.from(order).averagePrice(averagePrice).build());
+    }
+
+    /**
+     * Check if the account as enough fund to pass the order.
+     * Throw a FundsExceededException if the funds are not sufficient
+     */
+    private void checkBalance(LimitOrder order) {
+        if(exchangeService.getExchangeMetadata(exchange).getMargin())
+            return;
+
+        BigDecimal counterDelta = getCounterDelta(order);
+        BigDecimal baseDelta = getBaseDelta(order);
+        if(exchange.getPaperAccountService().getBalance(order.getCurrencyPair().counter).add(counterDelta).compareTo(BigDecimal.ZERO) <0)
+            throw new FundsExceededException();
+        if(exchange.getPaperAccountService().getBalance(order.getCurrencyPair().base).add(baseDelta).compareTo(BigDecimal.ZERO) <0)
+            throw new FundsExceededException();
+    }
+
+    /**
+     * Get the amount of currency.counter (ie. fiat) that will be added/subtracted to the fiat balance
+     * If available, this use the order average price; if not available this uses the limit price instead (for new orders)
+     * @param order the order
+     * @return the currency.base delta
+     */
+    private BigDecimal getCounterDelta(LimitOrder order) {
+        BigDecimal cumulativeCounterAmount = order.getAveragePrice() != null ? order.getOriginalAmount().multiply(order.getAveragePrice()) : order.getOriginalAmount().multiply(order.getLimitPrice());
+
+        //Calculate fees in fiat currency
+        BigDecimal counterFee = getCounterFee(order);
+
+        //Find the total cost of the order
+        BigDecimal counterDelta = order.getType()== ASK ? cumulativeCounterAmount: cumulativeCounterAmount.negate();
+        counterDelta = counterDelta.subtract(counterFee).setScale(USD_SCALE, RoundingMode.FLOOR);
+        return counterDelta;
+    }
+
+    /**
+     * Get the amount of currency.base (ie. crypto) that will be added/subtracted to the balance
+     * @param order the order
+     * @return the currency.base delta
+     */
+    private BigDecimal getBaseDelta(LimitOrder order) {
+        BigDecimal feePercentage = exchangeService.getExchangeFee(exchange, order.getCurrencyPair(), false);
+
+        //Calculate fees in crypto currency
+        BigDecimal baseFee = exchangeService.getExchangeMetadata(exchange).getFeeComputation() == SERVER ? BigDecimal.ZERO : order.getOriginalAmount().multiply(feePercentage).setScale(BTC_SCALE,RoundingMode.HALF_EVEN);
+
+        //Find the total volume of the order
+        BigDecimal baseDelta = order.getType()== ASK ? order.getOriginalAmount().negate(): order.getOriginalAmount();
+        baseDelta = baseDelta.subtract(baseFee);
+        return baseDelta;
+    }
+
+    /**
+     * Get the fiat fees for the order
+     * @param order the order
+     * @return the fees in the counter currency
+     */
+    private BigDecimal getCounterFee(LimitOrder order) {
+        BigDecimal cumulativeCounterAmount = order.getAveragePrice() != null ? order.getOriginalAmount().multiply(order.getAveragePrice()) : order.getOriginalAmount().multiply(order.getLimitPrice());
+        BigDecimal feePercentage = exchangeService.getExchangeFee(exchange, order.getCurrencyPair(), false);
+        return exchangeService.getExchangeMetadata(exchange).getFeeComputation() == SERVER ? cumulativeCounterAmount.multiply(feePercentage) : BigDecimal.ZERO;
+    }
 }

--- a/src/test/java/com/r307/arbitrader/service/paper/PaperTradeServiceTest.java
+++ b/src/test/java/com/r307/arbitrader/service/paper/PaperTradeServiceTest.java
@@ -1,0 +1,148 @@
+package com.r307.arbitrader.service.paper;
+
+import com.r307.arbitrader.BaseTestCase;
+import com.r307.arbitrader.config.ExchangeConfiguration;
+import com.r307.arbitrader.config.FeeComputation;
+import com.r307.arbitrader.config.PaperConfiguration;
+import com.r307.arbitrader.service.ExchangeService;
+import com.r307.arbitrader.service.TickerService;
+import com.r307.arbitrader.service.TradingService;
+import org.junit.Before;
+import org.junit.Test;
+import org.knowm.xchange.Exchange;
+import org.knowm.xchange.ExchangeSpecification;
+import org.knowm.xchange.currency.Currency;
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.dto.Order;
+import org.knowm.xchange.dto.meta.ExchangeMetaData;
+import org.knowm.xchange.dto.trade.LimitOrder;
+import org.knowm.xchange.exceptions.ExchangeException;
+import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
+import org.knowm.xchange.service.account.AccountService;
+import org.knowm.xchange.service.marketdata.MarketDataService;
+import org.knowm.xchange.service.trade.TradeService;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import si.mazi.rescu.SynchronizedValueFactory;
+
+import java.awt.print.Paper;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+import static com.r307.arbitrader.DecimalConstants.BTC_SCALE;
+import static com.r307.arbitrader.DecimalConstants.USD_SCALE;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+public class PaperTradeServiceTest extends BaseTestCase {
+
+    PaperExchange paperExchange;
+    PaperTradeService paperTradeService;
+
+
+    ExchangeConfiguration exchangeConfiguration;
+
+    @Mock
+    private TickerService tickerService;
+
+    @Mock
+    private ExchangeService exchangeService;
+
+    @Mock
+    private Exchange exchange;
+
+    @Before
+    public void setUp() {
+        PaperConfiguration paperConfiguration = new PaperConfiguration();
+        paperConfiguration.setActive(true);
+        paperConfiguration.setInitialBalance(new BigDecimal("100"));
+        exchangeConfiguration = new ExchangeConfiguration();
+
+        paperExchange = new PaperExchange(exchange, Currency.USD,tickerService, exchangeService, paperConfiguration);
+        paperTradeService = paperExchange.getPaperTradeService();
+
+        when(exchange.getExchangeSpecification()).thenReturn(new ExchangeSpecification(PaperExchange.class));
+        when(exchangeService.getExchangeMetadata(any(Exchange.class))).thenReturn(exchangeConfiguration);
+    }
+
+    @Test
+    public void testFillOrderBuyFeeComputationClient() {
+        exchangeConfiguration.setFeeComputation(FeeComputation.CLIENT);
+        when(exchangeService.getExchangeMetadata(any(Exchange.class))).thenReturn(exchangeConfiguration);
+        when(exchangeService.getExchangeFee(any(Exchange.class),any(CurrencyPair.class),anyBoolean())).thenReturn(new BigDecimal("0.001"));
+
+        //TODO this test use ad-hock data, test with real data!
+        //tradingService.addFees(...,...,5) will return 5.005
+        LimitOrder order = new LimitOrder.Builder(Order.OrderType.BID, CurrencyPair.BTC_USD)
+            .originalAmount(new BigDecimal("5.005"))
+            .timestamp(new Date())
+            .limitPrice(new BigDecimal("10"))
+            .orderStatus(Order.OrderStatus.NEW)
+            .build();
+
+        paperTradeService.fillOrder(order, order.getLimitPrice());
+        assertEquals(new BigDecimal("49.95").setScale(2, RoundingMode.HALF_EVEN), paperExchange.getPaperAccountService().getBalance(Currency.USD).setScale(2, RoundingMode.HALF_EVEN));
+        assertEquals(new BigDecimal("5").setScale(BTC_SCALE, RoundingMode.HALF_EVEN), paperExchange.getPaperAccountService().getBalance(Currency.BTC).setScale(BTC_SCALE, RoundingMode.HALF_EVEN));
+    }
+
+    @Test
+    public void testFillOrderSellFeeComputationClient() {
+        exchangeConfiguration.setFeeComputation(FeeComputation.CLIENT);
+        when(exchangeService.getExchangeMetadata(any(Exchange.class))).thenReturn(exchangeConfiguration);
+        when(exchangeService.getExchangeFee(any(Exchange.class),any(CurrencyPair.class),anyBoolean())).thenReturn(new BigDecimal("0.001"));
+
+        //TODO this test use ad-hock data, test with real data!
+        //tradingService.subtractFees(...,...,5) will return 4.995
+        LimitOrder order = new LimitOrder.Builder(Order.OrderType.ASK, CurrencyPair.BTC_USD)
+            .originalAmount(new BigDecimal("4.995"))
+            .timestamp(new Date())
+            .limitPrice(new BigDecimal("10"))
+            .orderStatus(Order.OrderStatus.NEW)
+            .build();
+
+        paperTradeService.fillOrder(order, order.getLimitPrice());
+        assertEquals(new BigDecimal("149.95").setScale(USD_SCALE, RoundingMode.HALF_EVEN), paperExchange.getPaperAccountService().getBalance(Currency.USD).setScale(USD_SCALE, RoundingMode.HALF_EVEN));
+        assertEquals(new BigDecimal("-5").setScale(BTC_SCALE, RoundingMode.HALF_EVEN), paperExchange.getPaperAccountService().getBalance(Currency.BTC).setScale(BTC_SCALE, RoundingMode.HALF_EVEN));
+    }
+
+    @Test
+    public void testFillOrderBuyFeeComputationServer() {
+        exchangeConfiguration.setFeeComputation(FeeComputation.SERVER);
+        when(exchangeService.getExchangeMetadata(any(Exchange.class))).thenReturn(exchangeConfiguration);
+        when(exchangeService.getExchangeFee(any(Exchange.class),any(CurrencyPair.class),anyBoolean())).thenReturn(new BigDecimal("0.001"));
+
+        LimitOrder order = new LimitOrder.Builder(Order.OrderType.BID, CurrencyPair.BTC_USD)
+            .originalAmount(new BigDecimal("5"))
+            .timestamp(new Date())
+            .limitPrice(new BigDecimal("10"))
+            .orderStatus(Order.OrderStatus.NEW)
+            .build();
+
+        paperTradeService.fillOrder(order, order.getLimitPrice());
+
+        assertEquals(new BigDecimal("49.95").setScale(2, RoundingMode.HALF_EVEN), paperExchange.getPaperAccountService().getBalance(Currency.USD).setScale(2, RoundingMode.HALF_EVEN));
+        assertEquals(new BigDecimal("5").setScale(BTC_SCALE, RoundingMode.HALF_EVEN), paperExchange.getPaperAccountService().getBalance(Currency.BTC).setScale(BTC_SCALE, RoundingMode.HALF_EVEN));
+    }
+
+    @Test
+    public void testFillOrderSellFeeComputationServer() {
+        exchangeConfiguration.setFeeComputation(FeeComputation.SERVER);
+        when(exchangeService.getExchangeFee(any(Exchange.class),any(CurrencyPair.class),anyBoolean())).thenReturn(new BigDecimal("0.001"));
+
+        LimitOrder order = new LimitOrder.Builder(Order.OrderType.ASK, CurrencyPair.BTC_USD)
+            .originalAmount(new BigDecimal("5"))
+            .timestamp(new Date())
+            .limitPrice(new BigDecimal("10"))
+            .orderStatus(Order.OrderStatus.NEW)
+            .build();
+
+        paperTradeService.fillOrder(order, order.getLimitPrice());
+        assertEquals(new BigDecimal("149.95").setScale(USD_SCALE, RoundingMode.HALF_EVEN), paperExchange.getPaperAccountService().getBalance(Currency.USD).setScale(USD_SCALE, RoundingMode.HALF_EVEN));
+        assertEquals(new BigDecimal("-5").setScale(BTC_SCALE, RoundingMode.HALF_EVEN), paperExchange.getPaperAccountService().getBalance(Currency.BTC).setScale(BTC_SCALE, RoundingMode.HALF_EVEN));
+    }
+}

--- a/src/test/java/com/r307/arbitrader/service/paper/PaperTradeServiceTest.java
+++ b/src/test/java/com/r307/arbitrader/service/paper/PaperTradeServiceTest.java
@@ -6,7 +6,6 @@ import com.r307.arbitrader.config.FeeComputation;
 import com.r307.arbitrader.config.PaperConfiguration;
 import com.r307.arbitrader.service.ExchangeService;
 import com.r307.arbitrader.service.TickerService;
-import com.r307.arbitrader.service.TradingService;
 import org.junit.Before;
 import org.junit.Test;
 import org.knowm.xchange.Exchange;
@@ -14,28 +13,20 @@ import org.knowm.xchange.ExchangeSpecification;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.Order;
-import org.knowm.xchange.dto.meta.ExchangeMetaData;
+import org.knowm.xchange.dto.meta.*;
 import org.knowm.xchange.dto.trade.LimitOrder;
-import org.knowm.xchange.exceptions.ExchangeException;
-import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
-import org.knowm.xchange.service.account.AccountService;
-import org.knowm.xchange.service.marketdata.MarketDataService;
-import org.knowm.xchange.service.trade.TradeService;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import si.mazi.rescu.SynchronizedValueFactory;
+import org.knowm.xchange.exceptions.FundsExceededException;
 
-import java.awt.print.Paper;
-import java.io.IOException;
+import org.mockito.Mock;
+
 import java.math.BigDecimal;
 import java.math.RoundingMode;
-import java.util.Date;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 
 import static com.r307.arbitrader.DecimalConstants.BTC_SCALE;
 import static com.r307.arbitrader.DecimalConstants.USD_SCALE;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -65,56 +56,161 @@ public class PaperTradeServiceTest extends BaseTestCase {
 
         paperExchange = new PaperExchange(exchange, Currency.USD,tickerService, exchangeService, paperConfiguration);
         paperTradeService = paperExchange.getPaperTradeService();
+        paperExchange.getPaperAccountService().putCoin(Currency.BTC, new BigDecimal("10"));
 
         when(exchange.getExchangeSpecification()).thenReturn(new ExchangeSpecification(PaperExchange.class));
         when(exchangeService.getExchangeMetadata(any(Exchange.class))).thenReturn(exchangeConfiguration);
+        when(exchangeService.getExchangeFee(any(Exchange.class),any(CurrencyPair.class),anyBoolean())).thenReturn(new BigDecimal("0.002"));
+    }
+
+
+
+
+    @Test
+    public void testPlaceAndGetOrder() {
+        exchangeConfiguration.setFeeComputation(FeeComputation.SERVER);
+        exchangeConfiguration.setMargin(false);
+
+        LimitOrder order = new LimitOrder.Builder(Order.OrderType.BID, CurrencyPair.BTC_USD)
+            .originalAmount(new BigDecimal("3"))
+            .timestamp(new Date())
+            .limitPrice(new BigDecimal("20"))
+            .orderStatus(Order.OrderStatus.NEW)
+            .build();
+
+        String id = paperTradeService.placeLimitOrder(order);
+        assertEquals(new BigDecimal("3"), paperTradeService.getOrder(id).stream().findFirst().get().getOriginalAmount());
+    }
+
+    @Test
+    public void testPlaceOrderFundExceeded() {
+        exchangeConfiguration.setFeeComputation(FeeComputation.SERVER);
+        exchangeConfiguration.setMargin(false);
+
+        LimitOrder order = new LimitOrder.Builder(Order.OrderType.ASK, CurrencyPair.BTC_USD)
+            .originalAmount(new BigDecimal("11"))
+            .timestamp(new Date())
+            .limitPrice(new BigDecimal("20"))
+            .orderStatus(Order.OrderStatus.NEW)
+            .build();
+
+        assertThrows(FundsExceededException.class, () -> paperTradeService.placeLimitOrder(order));
+    }
+
+    @Test
+    public void testPlaceOrderFundExceededMargin() {
+        exchangeConfiguration.setFeeComputation(FeeComputation.SERVER);
+        exchangeConfiguration.setMargin(true);
+
+        LimitOrder order = new LimitOrder.Builder(Order.OrderType.ASK, CurrencyPair.BTC_USD)
+            .originalAmount(new BigDecimal("11"))
+            .timestamp(new Date())
+            .limitPrice(new BigDecimal("20"))
+            .orderStatus(Order.OrderStatus.NEW)
+            .build();
+
+        paperTradeService.placeLimitOrder(order);
+    }
+
+    @Test
+    public void testFillOrderBuyFundExceeded() {
+        exchangeConfiguration.setFeeComputation(FeeComputation.SERVER);
+        exchangeConfiguration.setMargin(false);
+
+        LimitOrder order = new LimitOrder.Builder(Order.OrderType.BID, CurrencyPair.BTC_USD)
+            .originalAmount(new BigDecimal("7"))
+            .timestamp(new Date())
+            .limitPrice(new BigDecimal("20"))
+            .orderStatus(Order.OrderStatus.NEW)
+            .build();
+
+        assertThrows(FundsExceededException.class, () -> paperTradeService.fillOrder(order, order.getLimitPrice()));
+    }
+
+    @Test
+    public void testFillOrderSellFundExceeded() {
+        exchangeConfiguration.setFeeComputation(FeeComputation.SERVER);
+        exchangeConfiguration.setMargin(false);
+
+        LimitOrder order = new LimitOrder.Builder(Order.OrderType.ASK, CurrencyPair.BTC_USD)
+            .originalAmount(new BigDecimal("15"))
+            .timestamp(new Date())
+            .limitPrice(new BigDecimal("20"))
+            .orderStatus(Order.OrderStatus.NEW)
+            .build();
+
+        assertThrows(FundsExceededException.class, () -> paperTradeService.fillOrder(order, order.getLimitPrice()));
+    }
+
+    @Test
+    public void testFillOrderBuyFeeComputationClientFundExceeded() {
+        exchangeConfiguration.setFeeComputation(FeeComputation.CLIENT);
+        exchangeConfiguration.setMargin(false);
+
+        LimitOrder order = new LimitOrder.Builder(Order.OrderType.BID, CurrencyPair.BTC_USD)
+            .originalAmount(new BigDecimal("15"))
+            .timestamp(new Date())
+            .limitPrice(new BigDecimal("20"))
+            .orderStatus(Order.OrderStatus.NEW)
+            .build();
+
+        assertThrows(FundsExceededException.class, () -> paperTradeService.fillOrder(order, order.getLimitPrice()));
+    }
+
+    @Test
+    public void testFillOrderSellFeeComputationClientFundExceeded() {
+        exchangeConfiguration.setFeeComputation(FeeComputation.CLIENT);
+        exchangeConfiguration.setMargin(false);
+
+        LimitOrder order = new LimitOrder.Builder(Order.OrderType.ASK, CurrencyPair.BTC_USD)
+            .originalAmount(new BigDecimal("10"))
+            .timestamp(new Date())
+            .limitPrice(new BigDecimal("5"))
+            .orderStatus(Order.OrderStatus.NEW)
+            .build();
+
+        assertThrows(FundsExceededException.class, () -> paperTradeService.fillOrder(order, order.getLimitPrice()));
     }
 
     @Test
     public void testFillOrderBuyFeeComputationClient() {
         exchangeConfiguration.setFeeComputation(FeeComputation.CLIENT);
-        when(exchangeService.getExchangeMetadata(any(Exchange.class))).thenReturn(exchangeConfiguration);
-        when(exchangeService.getExchangeFee(any(Exchange.class),any(CurrencyPair.class),anyBoolean())).thenReturn(new BigDecimal("0.001"));
+        exchangeConfiguration.setMargin(false);
 
-        //TODO this test use ad-hock data, test with real data!
-        //tradingService.addFees(...,...,5) will return 5.005
         LimitOrder order = new LimitOrder.Builder(Order.OrderType.BID, CurrencyPair.BTC_USD)
-            .originalAmount(new BigDecimal("5.005"))
+            .originalAmount(new BigDecimal("0.00125048"))
             .timestamp(new Date())
-            .limitPrice(new BigDecimal("10"))
+            .limitPrice(new BigDecimal("15993.90"))
             .orderStatus(Order.OrderStatus.NEW)
             .build();
 
         paperTradeService.fillOrder(order, order.getLimitPrice());
-        assertEquals(new BigDecimal("49.95").setScale(2, RoundingMode.HALF_EVEN), paperExchange.getPaperAccountService().getBalance(Currency.USD).setScale(2, RoundingMode.HALF_EVEN));
-        assertEquals(new BigDecimal("5").setScale(BTC_SCALE, RoundingMode.HALF_EVEN), paperExchange.getPaperAccountService().getBalance(Currency.BTC).setScale(BTC_SCALE, RoundingMode.HALF_EVEN));
+        assertEquals(new BigDecimal("79.99").setScale(USD_SCALE, RoundingMode.HALF_EVEN), paperExchange.getPaperAccountService().getBalance(Currency.USD).setScale(USD_SCALE, RoundingMode.HALF_EVEN));
+        assertEquals(new BigDecimal("10.00124798").setScale(BTC_SCALE, RoundingMode.HALF_EVEN), paperExchange.getPaperAccountService().getBalance(Currency.BTC).setScale(BTC_SCALE, RoundingMode.HALF_EVEN));
     }
+
 
     @Test
     public void testFillOrderSellFeeComputationClient() {
         exchangeConfiguration.setFeeComputation(FeeComputation.CLIENT);
-        when(exchangeService.getExchangeMetadata(any(Exchange.class))).thenReturn(exchangeConfiguration);
-        when(exchangeService.getExchangeFee(any(Exchange.class),any(CurrencyPair.class),anyBoolean())).thenReturn(new BigDecimal("0.001"));
+        exchangeConfiguration.setMargin(false);
 
-        //TODO this test use ad-hock data, test with real data!
-        //tradingService.subtractFees(...,...,5) will return 4.995
         LimitOrder order = new LimitOrder.Builder(Order.OrderType.ASK, CurrencyPair.BTC_USD)
-            .originalAmount(new BigDecimal("4.995"))
+            .originalAmount(new BigDecimal("0.00124549"))
             .timestamp(new Date())
-            .limitPrice(new BigDecimal("10"))
+            .limitPrice(new BigDecimal("16052.89"))
             .orderStatus(Order.OrderStatus.NEW)
             .build();
 
         paperTradeService.fillOrder(order, order.getLimitPrice());
-        assertEquals(new BigDecimal("149.95").setScale(USD_SCALE, RoundingMode.HALF_EVEN), paperExchange.getPaperAccountService().getBalance(Currency.USD).setScale(USD_SCALE, RoundingMode.HALF_EVEN));
-        assertEquals(new BigDecimal("-5").setScale(BTC_SCALE, RoundingMode.HALF_EVEN), paperExchange.getPaperAccountService().getBalance(Currency.BTC).setScale(BTC_SCALE, RoundingMode.HALF_EVEN));
+        assertEquals(new BigDecimal("119.99").setScale(USD_SCALE, RoundingMode.HALF_EVEN), paperExchange.getPaperAccountService().getBalance(Currency.USD).setScale(USD_SCALE, RoundingMode.HALF_EVEN));
+        assertEquals(new BigDecimal("9.99875202").setScale(BTC_SCALE, RoundingMode.HALF_EVEN), paperExchange.getPaperAccountService().getBalance(Currency.BTC).setScale(BTC_SCALE, RoundingMode.HALF_EVEN));
     }
 
     @Test
     public void testFillOrderBuyFeeComputationServer() {
         exchangeConfiguration.setFeeComputation(FeeComputation.SERVER);
-        when(exchangeService.getExchangeMetadata(any(Exchange.class))).thenReturn(exchangeConfiguration);
-        when(exchangeService.getExchangeFee(any(Exchange.class),any(CurrencyPair.class),anyBoolean())).thenReturn(new BigDecimal("0.001"));
+        exchangeConfiguration.setMargin(false);
 
         LimitOrder order = new LimitOrder.Builder(Order.OrderType.BID, CurrencyPair.BTC_USD)
             .originalAmount(new BigDecimal("5"))
@@ -125,14 +221,14 @@ public class PaperTradeServiceTest extends BaseTestCase {
 
         paperTradeService.fillOrder(order, order.getLimitPrice());
 
-        assertEquals(new BigDecimal("49.95").setScale(2, RoundingMode.HALF_EVEN), paperExchange.getPaperAccountService().getBalance(Currency.USD).setScale(2, RoundingMode.HALF_EVEN));
-        assertEquals(new BigDecimal("5").setScale(BTC_SCALE, RoundingMode.HALF_EVEN), paperExchange.getPaperAccountService().getBalance(Currency.BTC).setScale(BTC_SCALE, RoundingMode.HALF_EVEN));
+        assertEquals(new BigDecimal("49.90").setScale(USD_SCALE, RoundingMode.HALF_EVEN), paperExchange.getPaperAccountService().getBalance(Currency.USD).setScale(USD_SCALE, RoundingMode.HALF_EVEN));
+        assertEquals(new BigDecimal("15").setScale(BTC_SCALE, RoundingMode.HALF_EVEN), paperExchange.getPaperAccountService().getBalance(Currency.BTC).setScale(BTC_SCALE, RoundingMode.HALF_EVEN));
     }
 
     @Test
     public void testFillOrderSellFeeComputationServer() {
         exchangeConfiguration.setFeeComputation(FeeComputation.SERVER);
-        when(exchangeService.getExchangeFee(any(Exchange.class),any(CurrencyPair.class),anyBoolean())).thenReturn(new BigDecimal("0.001"));
+        exchangeConfiguration.setMargin(false);
 
         LimitOrder order = new LimitOrder.Builder(Order.OrderType.ASK, CurrencyPair.BTC_USD)
             .originalAmount(new BigDecimal("5"))
@@ -142,7 +238,7 @@ public class PaperTradeServiceTest extends BaseTestCase {
             .build();
 
         paperTradeService.fillOrder(order, order.getLimitPrice());
-        assertEquals(new BigDecimal("149.95").setScale(USD_SCALE, RoundingMode.HALF_EVEN), paperExchange.getPaperAccountService().getBalance(Currency.USD).setScale(USD_SCALE, RoundingMode.HALF_EVEN));
-        assertEquals(new BigDecimal("-5").setScale(BTC_SCALE, RoundingMode.HALF_EVEN), paperExchange.getPaperAccountService().getBalance(Currency.BTC).setScale(BTC_SCALE, RoundingMode.HALF_EVEN));
+        assertEquals(new BigDecimal("149.90").setScale(USD_SCALE, RoundingMode.HALF_EVEN), paperExchange.getPaperAccountService().getBalance(Currency.USD).setScale(USD_SCALE, RoundingMode.HALF_EVEN));
+        assertEquals(new BigDecimal("5").setScale(BTC_SCALE, RoundingMode.HALF_EVEN), paperExchange.getPaperAccountService().getBalance(Currency.BTC).setScale(BTC_SCALE, RoundingMode.HALF_EVEN));
     }
 }


### PR DESCRIPTION
This commit:
- enables the FeeComputation.CLIENT exchanges to work with PaperTrading. The calculation is the opposite to the addFees/subtractfees method.
- unit tests the PaperTradeService.fillOrder method. The FeeComputation.CLIENT test need real data.
- keep track of all the balances of the PaperAccountService, not only the cash balance