### PR TITLE
Remove duplicated '-' on the groupId when sending a message via Telegram

### DIFF
--- a/src/main/java/com/r307/arbitrader/config/NotificationConfiguration.java
+++ b/src/main/java/com/r307/arbitrader/config/NotificationConfiguration.java
@@ -171,7 +171,7 @@ public class NotificationConfiguration {
             // a message to this group, we replace the 'g' from the user config input and/or append the '-' to the start
             // of the groupId string
             if (!StringUtils.isBlank(groupId) && groupId.startsWith("g")) {
-                this.groupId = "-" + groupId.substring(1, groupId.length() - 1);
+                this.groupId = "-" + groupId.substring(1);
                 return;
             }
             if (!StringUtils.isBlank(groupId) && !groupId.startsWith("g")) {

--- a/src/main/java/com/r307/arbitrader/service/NotificationServiceImpl.java
+++ b/src/main/java/com/r307/arbitrader/service/NotificationServiceImpl.java
@@ -199,8 +199,7 @@ public class NotificationServiceImpl implements NotificationService {
         }
 
         try {
-            // Telegram groupId must always start with a '-'
-            telegramClient.sendMessage(message, "-" + groupId);
+            telegramClient.sendMessage(message, groupId);
         }
         catch (Exception e) {
             LOGGER.error("Could not instant message notification to groupId {}. Reason: {}", groupId, e.getMessage());


### PR DESCRIPTION
The '-' is already appended to the groupId on the `setGroupId`. I forgot to remove it from here