### PR TITLE
fix stream binance bug due to homeCurrencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,9 @@ targetCompatibility = 1.8
 repositories {
     mavenLocal()
     mavenCentral()
+    maven {
+        url "https://oss.sonatype.org/content/repositories/snapshots"
+    }
 }
 
 configurations.compile {
@@ -46,16 +49,17 @@ dependencies {
     compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310'
     compile group: 'com.squareup.okhttp3', name:'okhttp', version:'4.9.1'
 
-    compile group: 'org.knowm.xchange', name: 'xchange-quoine', version: '5.0.4'
-    compile group: 'org.knowm.xchange', name: 'xchange-stream-kraken', version: '5.0.4'
-    compile group: 'org.knowm.xchange', name: 'xchange-bitflyer', version: '5.0.4'
-    compile group: 'org.knowm.xchange', name: 'xchange-stream-coinbasepro', version: '5.0.4'
-    compile group: 'org.knowm.xchange', name: 'xchange-cexio', version: '5.0.4'
-    compile group: 'org.knowm.xchange', name: 'xchange-poloniex', version: '5.0.4'
-    compile group: 'org.knowm.xchange', name: 'xchange-stream-gemini', version: '5.0.4'
-    compile group: 'org.knowm.xchange', name: 'xchange-bitstamp', version: '5.0.4'
-    compile group: 'org.knowm.xchange', name: 'xchange-cobinhood', version: '5.0.4'
-    compile group: 'org.knowm.xchange', name: 'xchange-binance', version: '5.0.4'
+    compile group: 'org.knowm.xchange', name: 'xchange-quoine', version: '5.0.6'
+    compile group: 'org.knowm.xchange', name: 'xchange-stream-kraken', version: '5.0.6'
+    compile group: 'org.knowm.xchange', name: 'xchange-bitflyer', version: '5.0.6'
+    compile group: 'org.knowm.xchange', name: 'xchange-stream-coinbasepro', version: '5.0.6'
+    compile group: 'org.knowm.xchange', name: 'xchange-cexio', version: '5.0.6'
+    compile group: 'org.knowm.xchange', name: 'xchange-poloniex', version: '5.0.6'
+    compile group: 'org.knowm.xchange', name: 'xchange-stream-gemini', version: '5.0.6'
+    compile group: 'org.knowm.xchange', name: 'xchange-bitstamp', version: '5.0.6'
+    compile group: 'org.knowm.xchange', name: 'xchange-cobinhood', version: '5.0.6'
+    compile group: 'org.knowm.xchange', name: 'xchange-binance', version: '5.0.6'
+    compile group: 'org.knowm.xchange', name: 'xchange-stream-binance', version: '5.0.6'
 
     compile group: 'com.github.seratch', name: 'jslack', version: '1.1.6'
     compile group: 'javax.websocket', name: 'javax.websocket-api', version: '1.1'

--- a/build.gradle
+++ b/build.gradle
@@ -31,9 +31,6 @@ targetCompatibility = 1.8
 repositories {
     mavenLocal()
     mavenCentral()
-    maven {
-        url "https://oss.sonatype.org/content/repositories/snapshots"
-    }
 }
 
 configurations.compile {
@@ -49,17 +46,16 @@ dependencies {
     compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310'
     compile group: 'com.squareup.okhttp3', name:'okhttp', version:'4.9.1'
 
-    compile group: 'org.knowm.xchange', name: 'xchange-quoine', version: '5.0.6'
-    compile group: 'org.knowm.xchange', name: 'xchange-stream-kraken', version: '5.0.6'
-    compile group: 'org.knowm.xchange', name: 'xchange-bitflyer', version: '5.0.6'
-    compile group: 'org.knowm.xchange', name: 'xchange-stream-coinbasepro', version: '5.0.6'
-    compile group: 'org.knowm.xchange', name: 'xchange-cexio', version: '5.0.6'
-    compile group: 'org.knowm.xchange', name: 'xchange-poloniex', version: '5.0.6'
-    compile group: 'org.knowm.xchange', name: 'xchange-stream-gemini', version: '5.0.6'
-    compile group: 'org.knowm.xchange', name: 'xchange-bitstamp', version: '5.0.6'
-    compile group: 'org.knowm.xchange', name: 'xchange-cobinhood', version: '5.0.6'
-    compile group: 'org.knowm.xchange', name: 'xchange-binance', version: '5.0.6'
-    compile group: 'org.knowm.xchange', name: 'xchange-stream-binance', version: '5.0.6'
+    compile group: 'org.knowm.xchange', name: 'xchange-quoine', version: '5.0.4'
+    compile group: 'org.knowm.xchange', name: 'xchange-stream-kraken', version: '5.0.4'
+    compile group: 'org.knowm.xchange', name: 'xchange-bitflyer', version: '5.0.4'
+    compile group: 'org.knowm.xchange', name: 'xchange-stream-coinbasepro', version: '5.0.4'
+    compile group: 'org.knowm.xchange', name: 'xchange-cexio', version: '5.0.4'
+    compile group: 'org.knowm.xchange', name: 'xchange-poloniex', version: '5.0.4'
+    compile group: 'org.knowm.xchange', name: 'xchange-stream-gemini', version: '5.0.4'
+    compile group: 'org.knowm.xchange', name: 'xchange-bitstamp', version: '5.0.4'
+    compile group: 'org.knowm.xchange', name: 'xchange-cobinhood', version: '5.0.4'
+    compile group: 'org.knowm.xchange', name: 'xchange-binance', version: '5.0.4'
 
     compile group: 'com.github.seratch', name: 'jslack', version: '1.1.6'
     compile group: 'javax.websocket', name: 'javax.websocket-api', version: '1.1'

--- a/src/main/java/com/r307/arbitrader/service/ticker/StreamingTickerStrategy.java
+++ b/src/main/java/com/r307/arbitrader/service/ticker/StreamingTickerStrategy.java
@@ -52,7 +52,7 @@ public class StreamingTickerStrategy implements TickerStrategy {
         if (!tickers.containsKey(exchange)) { // we're not receiving prices so we need to (re)connect
             ProductSubscription.ProductSubscriptionBuilder builder = ProductSubscription.create();
 
-            currencyPairs.forEach(builder::addTicker);
+            currencyPairs.forEach(pair -> { builder.addTicker(exchangeService.convertExchangePair(exchange, pair)); });
 
             // try to subscribe to the websocket
             exchange.connect(builder.build()).blockingAwait();


### PR DESCRIPTION
This fixes #357 .

Quote from @scionaltera, the cause is basically:
> Another possibility is that we're putting the wrong CurrencyPairs in the ProductSubscription in StreamingTickerStrategy#getTickers() due to the homeCurrency setting. The code in the BinanceStreamingMarketDataService checks to see if the ticker you're asking for is in the original list created when the connection was first connected. If, for example, we put "BTC/USD" in at that point and "BTC/USDT" in later, or the reverse, that could cause this problem too.

Also upgraded to 5.0.6 so might be better merged after #354 . 