### PR TITLE
Bugfix: Send the whole message text when exiting a position due to timeout or forced exit command

### DIFF
--- a/src/main/java/com/r307/arbitrader/service/NotificationServiceImpl.java
+++ b/src/main/java/com/r307/arbitrader/service/NotificationServiceImpl.java
@@ -127,8 +127,18 @@ public class NotificationServiceImpl implements NotificationService {
 
         final BigDecimal profit = updatedBalance.subtract(entryBalance);
 
-        // This is equivalent of if(isActivePositionExpired) {timeout} else if(isForceExitPosition) {forced} else {exit}
-        final String message = isActivePositionExpired ? "***** TIMEOUT EXIT *****\n" : (isForceExitPosition ? "***** FORCED EXIT *****\n" : "***** EXIT *****\n") +
+        final String startOfMessage;
+        if (isActivePositionExpired) {
+            startOfMessage = "***** TIMEOUT EXIT *****\n";
+        }
+        else if (isForceExitPosition){
+            startOfMessage = "***** FORCED EXIT *****\n";
+        }
+        else {
+            startOfMessage =  "***** EXIT *****\n";
+        }
+
+        final String message = startOfMessage +
             exitSpreadString +
             longCloseString +
             shortCloseString +


### PR DESCRIPTION
Due to a bug in the `NotificationServiceImpl` class, if there is a forced exit or a timeout exit the notification message is missing the trade details.
Example of a message sent via telegram: [https://i.imgur.com/GUB5kRs.png](url)

As you can see, it is missing the:
Entry spread,  Exit spread target, Market neutrality rating and so on...