### PR TITLE
On TradingService#getVolumeForOrder null check volume and use currency.base scale instead of USD scale

### DIFF
--- a/src/main/java/com/r307/arbitrader/service/ExchangeService.java
+++ b/src/main/java/com/r307/arbitrader/service/ExchangeService.java
@@ -176,7 +176,7 @@ public class ExchangeService {
     }
 
     /**
-     * Get the account balance in a specific currency from an exchange using {@link DecimalConstants#USD_SCALE} as scale
+     * Get the account balance in a specific currency from an exchange using {@link DecimalConstants#USD_SCALE} as scale.
      *
      * @param exchange The Exchange to query.
      * @param currency The Currency to query.

--- a/src/main/java/com/r307/arbitrader/service/ExchangeService.java
+++ b/src/main/java/com/r307/arbitrader/service/ExchangeService.java
@@ -176,7 +176,7 @@ public class ExchangeService {
     }
 
     /**
-     * Get the account balance in a specific currency from an exchange.
+     * Get the account balance in a specific currency from an exchange using {@link DecimalConstants#USD_SCALE} as scale
      *
      * @param exchange The Exchange to query.
      * @param currency The Currency to query.

--- a/src/main/java/com/r307/arbitrader/service/TradingService.java
+++ b/src/main/java/com/r307/arbitrader/service/TradingService.java
@@ -796,10 +796,9 @@ public class TradingService {
         // we couldn't get an order volume by ID, so next we try to get the account balance
         // for the BASE pair (eg. the BTC in BTC/USD)
         try {
-            final CurrencyMetaData defaultMetaData = new CurrencyMetaData(BTC_SCALE, BigDecimal.ZERO);
             final Integer scale = exchange.getExchangeMetaData()
                 .getCurrencies()
-                .getOrDefault(currencyPair.base, defaultMetaData)
+                .getOrDefault(currencyPair.base, new CurrencyMetaData(BTC_SCALE, BigDecimal.ZERO))
                 .getScale();
 
             BigDecimal balance = exchangeService.getAccountBalance(exchange, currencyPair.base, scale);

--- a/src/main/java/com/r307/arbitrader/service/TradingService.java
+++ b/src/main/java/com/r307/arbitrader/service/TradingService.java
@@ -788,7 +788,7 @@ public class TradingService {
 
         // if we got a greater-than-zero volume, we're done
         // cache it and return it
-        if (BigDecimal.ZERO.compareTo(volume) < 0) {
+        if (volume != null && BigDecimal.ZERO.compareTo(volume) < 0) {
             orderVolumeCache.setCachedVolume(exchange, orderId, volume);
             return volume;
         }
@@ -796,7 +796,13 @@ public class TradingService {
         // we couldn't get an order volume by ID, so next we try to get the account balance
         // for the BASE pair (eg. the BTC in BTC/USD)
         try {
-            BigDecimal balance = exchangeService.getAccountBalance(exchange, currencyPair.base);
+            final CurrencyMetaData defaultMetaData = new CurrencyMetaData(BTC_SCALE, BigDecimal.ZERO);
+            final Integer scale = exchange.getExchangeMetaData()
+                .getCurrencies()
+                .getOrDefault(currencyPair.base, defaultMetaData)
+                .getScale();
+
+            BigDecimal balance = exchangeService.getAccountBalance(exchange, currencyPair.base, scale);
 
             if (BigDecimal.ZERO.compareTo(balance) < 0) {
                 LOGGER.debug("{}: Using {} balance: {}",

--- a/src/test/java/com/r307/arbitrader/service/TradingServiceTest.java
+++ b/src/test/java/com/r307/arbitrader/service/TradingServiceTest.java
@@ -108,7 +108,7 @@ public class TradingServiceTest extends BaseTestCase {
 
         doReturn(defaultValue)
             .when(exchangeService)
-            .getAccountBalance(any(Exchange.class), any(Currency.class));
+            .getAccountBalance(any(Exchange.class), any(Currency.class), any(Integer.class));
         when(longExchange.getTradeService().getOrder(eq("nullOrder"))).thenReturn(null);
         when(exchangeService.convertExchangePair(any(Exchange.class), any(CurrencyPair.class)))
             .thenReturn(currencyPair);
@@ -135,7 +135,7 @@ public class TradingServiceTest extends BaseTestCase {
     public void testGetVolumeForOrderNotAvailable() throws IOException {
         doReturn(new BigDecimal("90.0"))
             .when(exchangeService)
-            .getAccountBalance(any(Exchange.class), any(Currency.class));
+            .getAccountBalance(any(Exchange.class), any(Currency.class), any(Integer.class));
 
         when(exchangeService.convertExchangePair(any(Exchange.class), any(CurrencyPair.class)))
             .thenReturn(currencyPair);
@@ -153,7 +153,7 @@ public class TradingServiceTest extends BaseTestCase {
     public void testGetVolumeForOrderIOException() throws IOException {
         doReturn(new BigDecimal("90.0"))
             .when(exchangeService)
-            .getAccountBalance(any(Exchange.class), any(Currency.class));
+            .getAccountBalance(any(Exchange.class), any(Currency.class), any(Integer.class));
 
         when(exchangeService.convertExchangePair(any(Exchange.class), any(CurrencyPair.class)))
             .thenReturn(currencyPair);
@@ -171,7 +171,7 @@ public class TradingServiceTest extends BaseTestCase {
     public void testGetVolumeFallbackToDefaultZeroBalance() throws IOException {
         doReturn(BigDecimal.ZERO)
             .when(exchangeService)
-            .getAccountBalance(any(Exchange.class), any(Currency.class));
+            .getAccountBalance(any(Exchange.class), any(Currency.class), any(Integer.class));
 
         BigDecimal volume = tradingService.getVolumeForOrder(
             longExchange,
@@ -186,7 +186,7 @@ public class TradingServiceTest extends BaseTestCase {
     public void testGetVolumeFallbackToDefaultIOException() throws IOException {
         doThrow(new IOException("Boom!"))
             .when(exchangeService)
-            .getAccountBalance(any(Exchange.class), any(Currency.class));
+            .getAccountBalance(any(Exchange.class), any(Currency.class), any(Integer.class));
         when(exchangeService.convertExchangePair(any(Exchange.class), any(CurrencyPair.class)))
             .thenReturn(currencyPair);
 


### PR DESCRIPTION
In some cases the `volume` may be null and a NPE is thrown. To avoid that we do a null check before comparing the value of `volume`.

If `volume` is null we fallback to getting the amount of currency base we have in our account. The issue is here, before this PR we would always use USD scale, even for crypto currencies.