### PR TITLE
Effective spreads

### DIFF
--- a/application.example.yaml
+++ b/application.example.yaml
@@ -61,12 +61,18 @@ notifications:
     token: x
 
 trading:
-  # The percentage difference between the "long" and "short" exchanges before we will open our positions.
-  entrySpread: 0.0080
+  # The percentage difference between the "long" and "short" exchange prices - fees included - before we will open our positions.
+  # The real percentage difference will be bigger than this value to compensate for the trading fees.
+  entrySpreadTarget: 0.0010
 
-  # The percentage difference *in profit only* before we will close our positions.
-  # Fees will be added to this amount.
-  exitTarget: 0.0050
+  # The minimum profit in percentage before we will close our positions.
+  # ONLY ONE OF minimumProfit AND exitSpreadTarget CAN BE CONFIGURED AT ONCE
+  minimumProfit: 0.0001
+
+  # The percentage difference between the "long" and "short" exchange prices - fees included - before we will close our positions.
+  # The real percentage difference will be lower than this value to compensate for the trading fees.
+  # ONLY ONE OF minimumProfit AND exitSpreadTarget CAN BE CONFIGURED AT ONCE
+  # exitSpreadTarget: 0.00001
 
   # (Default: false)
   # Log notifications when a spreadIn reaches an all time high, or a spreadOut reaches an all time low.

--- a/application.example.yaml
+++ b/application.example.yaml
@@ -63,15 +63,17 @@ notifications:
 trading:
   # The percentage difference between the "long" and "short" exchange prices - fees included - before we will open our positions.
   # The real percentage difference will be bigger than this value to compensate for the trading fees.
+  # Increasing this value will make trades harder to enter
   entrySpreadTarget: 0.0010
 
   # The minimum profit in percentage before we will close our positions.
-  # ONLY ONE OF minimumProfit AND exitSpreadTarget CAN BE CONFIGURED AT ONCE
+  # Increasing this value will make trades harder to exit
   minimumProfit: 0.0001
 
+  # *** IF exitSpreadTarget IS SET minimumProfit WILL BE IGNORED ***
   # The percentage difference between the "long" and "short" exchange prices - fees included - before we will close our positions.
   # The real percentage difference will be lower than this value to compensate for the trading fees.
-  # ONLY ONE OF minimumProfit AND exitSpreadTarget CAN BE CONFIGURED AT ONCE
+  # If we want to wait until the long exchange price is bigger than the short exchange price before exiting the trade, we need to set a negative value.
   # exitSpreadTarget: 0.00001
 
   # (Default: false)

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
 apply plugin: 'docker'
 
 group 'com.r307'
-version '0.11.0-SNAPSHOT'
+version '0.12.0-SNAPSHOT'
 
 bootJar {
     manifest {

--- a/src/main/java/com/r307/arbitrader/config/TradingConfiguration.java
+++ b/src/main/java/com/r307/arbitrader/config/TradingConfiguration.java
@@ -19,7 +19,7 @@ import static com.r307.arbitrader.DecimalConstants.USD_SCALE;
 public class TradingConfiguration {
     private BigDecimal entrySpreadTarget;
     private BigDecimal exitSpreadTarget;
-    private BigDecimal minimumProfit;
+    private BigDecimal minimumProfit = BigDecimal.ZERO;
     private Boolean spreadNotifications = false;
     private BigDecimal fixedExposure;
     private List<ExchangeConfiguration> exchanges = new ArrayList<>();
@@ -27,7 +27,9 @@ public class TradingConfiguration {
     private Long tradeTimeout;
     private PaperConfiguration paper;
 
-    public BigDecimal getEntrySpreadTarget() { return entrySpreadTarget; }
+    public BigDecimal getEntrySpreadTarget() {
+        return entrySpreadTarget;
+    }
 
     public void setEntrySpreadTarget(BigDecimal entrySpreadTarget) {
         this.entrySpreadTarget = entrySpreadTarget;

--- a/src/main/java/com/r307/arbitrader/config/TradingConfiguration.java
+++ b/src/main/java/com/r307/arbitrader/config/TradingConfiguration.java
@@ -19,7 +19,7 @@ import static com.r307.arbitrader.DecimalConstants.USD_SCALE;
 public class TradingConfiguration {
     private BigDecimal entrySpreadTarget;
     private BigDecimal exitSpreadTarget;
-    private BigDecimal minimumProfit = BigDecimal.ZERO;
+    private BigDecimal minimumProfit;
     private Boolean spreadNotifications = false;
     private BigDecimal fixedExposure;
     private List<ExchangeConfiguration> exchanges = new ArrayList<>();

--- a/src/main/java/com/r307/arbitrader/config/TradingConfiguration.java
+++ b/src/main/java/com/r307/arbitrader/config/TradingConfiguration.java
@@ -17,8 +17,9 @@ import static com.r307.arbitrader.DecimalConstants.USD_SCALE;
 @ConfigurationProperties("trading")
 @Configuration
 public class TradingConfiguration {
-    private BigDecimal entrySpread;
-    private BigDecimal exitTarget;
+    private BigDecimal entrySpreadTarget;
+    private BigDecimal exitSpreadTarget;
+    private BigDecimal minimumProfit;
     private Boolean spreadNotifications = false;
     private BigDecimal fixedExposure;
     private List<ExchangeConfiguration> exchanges = new ArrayList<>();
@@ -26,20 +27,26 @@ public class TradingConfiguration {
     private Long tradeTimeout;
     private PaperConfiguration paper;
 
-    public BigDecimal getEntrySpread() {
-        return entrySpread;
+    public BigDecimal getEntrySpreadTarget() { return entrySpreadTarget; }
+
+    public void setEntrySpreadTarget(BigDecimal entrySpreadTarget) {
+        this.entrySpreadTarget = entrySpreadTarget;
     }
 
-    public void setEntrySpread(BigDecimal entrySpread) {
-        this.entrySpread = entrySpread;
+    public BigDecimal getExitSpreadTarget() {
+        return exitSpreadTarget;
     }
 
-    public BigDecimal getExitTarget() {
-        return exitTarget;
+    public void setExitSpreadTarget(BigDecimal exitSpreadTarget) {
+        this.exitSpreadTarget = exitSpreadTarget;
     }
 
-    public void setExitTarget(BigDecimal exitTarget) {
-        this.exitTarget = exitTarget;
+    public BigDecimal getMinimumProfit() {
+        return minimumProfit;
+    }
+
+    public void setMinimumProfit(BigDecimal minimumProfit) {
+        this.minimumProfit = minimumProfit;
     }
 
     public Boolean isSpreadNotifications() {

--- a/src/main/java/com/r307/arbitrader/service/SpreadService.java
+++ b/src/main/java/com/r307/arbitrader/service/SpreadService.java
@@ -211,7 +211,7 @@ public class SpreadService {
      */
     private BigDecimal computeEffectiveExitSpreadTarget(TradingConfiguration tradingConfiguration, BigDecimal entrySpread, BigDecimal longFee, BigDecimal shortFee) {
         if(tradingConfiguration.getExitSpreadTarget() != null) {
-            return tradingConfiguration.getEntrySpreadTarget();
+            return tradingConfiguration.getExitSpreadTarget();
         } else {
             BigDecimal profit = tradingConfiguration.getMinimumProfit() != null ? tradingConfiguration.getMinimumProfit() : BigDecimal.ZERO;
             BigDecimal effectiveEntrySpread = (BigDecimal.ONE.add(entrySpread)).multiply(BigDecimal.ONE.subtract(shortFee)).divide(BigDecimal.ONE.add(longFee), BTC_SCALE, RoundingMode.HALF_EVEN).subtract(BigDecimal.ONE);

--- a/src/main/java/com/r307/arbitrader/service/SpreadService.java
+++ b/src/main/java/com/r307/arbitrader/service/SpreadService.java
@@ -152,6 +152,55 @@ public class SpreadService {
         return (scaledShortPrice.subtract(scaledLongPrice)).divide(scaledLongPrice, RoundingMode.HALF_EVEN);
     }
 
+    /**
+     * Get the real entry spread target from the effective entry spread target (the real entry spread target is larger
+     * as it needs to compensate for the entry fees)
+     * @param tradingConfiguration the trading configuration
+     * @param longFee the long exchange fees in percentage
+     * @param shortFee the short exchange fees in percentage
+     * @return the real entry spread target
+     */
+    public BigDecimal getEntrySpreadTarget(TradingConfiguration tradingConfiguration, BigDecimal longFee, BigDecimal shortFee) {
+        return (BigDecimal.ONE.add(tradingConfiguration.getEntrySpreadTarget())).multiply(BigDecimal.ONE.add(longFee)).divide(BigDecimal.ONE.subtract(shortFee), BTC_SCALE, RoundingMode.HALF_EVEN).subtract(BigDecimal.ONE);
+    }
+
+    /**
+     * Get the real exit spread target from the trading configuration. The real exit spread target can be computed from
+     * the configured exitSpreadTarget or from the configured minimum profit. Both configuration should not be present
+     * at the same time.
+     * @param tradingConfiguration the trading configuration
+     * @param entrySpread the real entry spread
+     * @param longFee the long exchange fees in percentage
+     * @param shortFee the short exchange fees in percentage
+     * @return the real exit spread target
+     */
+    public BigDecimal getExitSpreadTarget(TradingConfiguration tradingConfiguration, BigDecimal entrySpread, BigDecimal longFee, BigDecimal shortFee) {
+        return computeExitSpreadTarget(computeEffectiveExitSpreadTarget(tradingConfiguration, entrySpread, longFee, shortFee), longFee, shortFee);
+    }
+
+    /*
+    * Calculate the real exit spread target from an effective exit spread target (the real exit spread target is lower
+    * as is needs to compensate for the exit fees)
+    */
+    private BigDecimal computeExitSpreadTarget(BigDecimal effectiveExitSpreadTarget, BigDecimal longFee, BigDecimal shortFee) {
+        return (BigDecimal.ONE.add(effectiveExitSpreadTarget)).multiply(BigDecimal.ONE.subtract(longFee)).divide(BigDecimal.ONE.add(shortFee), BTC_SCALE, RoundingMode.HALF_EVEN).subtract(BigDecimal.ONE);
+    }
+
+    /*
+    * Calculate the effective exit spread target either from the configured value or from the minimum profit percentage
+     */
+    private BigDecimal computeEffectiveExitSpreadTarget(TradingConfiguration tradingConfiguration, BigDecimal entrySpread, BigDecimal longFee, BigDecimal shortFee) {
+        if(tradingConfiguration.getExitSpreadTarget() != null) {
+            return tradingConfiguration.getEntrySpreadTarget();
+        } else {
+            BigDecimal profit = tradingConfiguration.getMinimumProfit() != null ? tradingConfiguration.getMinimumProfit() : BigDecimal.ZERO;
+            BigDecimal effectiveEntrySpread = (BigDecimal.ONE.add(entrySpread)).multiply(BigDecimal.ONE.subtract(shortFee)).divide(BigDecimal.ONE.add(longFee), BTC_SCALE, RoundingMode.HALF_EVEN).subtract(BigDecimal.ONE);
+            return effectiveEntrySpread.subtract(profit);
+        }
+    }
+
+
+
     // build a summary of the contents of a spread map (high/low water marks)
     private String buildSummary(Map<String, BigDecimal> spreadMap) {
         return spreadMap.entrySet()

--- a/src/main/java/com/r307/arbitrader/service/TradingScheduler.java
+++ b/src/main/java/com/r307/arbitrader/service/TradingScheduler.java
@@ -73,6 +73,10 @@ public class TradingScheduler {
      */
     @PostConstruct
     public void connectExchanges() {
+
+        if (tradingConfiguration.getExitSpreadTarget() != null && tradingConfiguration.getMinimumProfit() != null)
+            throw new RuntimeException("Only one of exitSpreadTarget and minimumProfit configuration options is allowed.");
+
         tradingConfiguration.getExchanges().forEach(exchangeMetadata -> {
             // skip exchanges that are explicitly disabled
             if (exchangeMetadata.getActive() != null && !exchangeMetadata.getActive()) {

--- a/src/main/java/com/r307/arbitrader/service/TradingScheduler.java
+++ b/src/main/java/com/r307/arbitrader/service/TradingScheduler.java
@@ -74,8 +74,8 @@ public class TradingScheduler {
     @PostConstruct
     public void connectExchanges() {
 
-        if (tradingConfiguration.getExitSpreadTarget() != null)
-            LOGGER.info("Property `exitSpreadTarget` is set, `minimumProfit` property setting will be ignored.");
+        if (tradingConfiguration.getExitSpreadTarget() != null && tradingConfiguration.getEntrySpreadTarget() != null)
+            LOGGER.warn("Property `exitSpreadTarget` is set, `minimumProfit` property will be ignored.");
 
         tradingConfiguration.getExchanges().forEach(exchangeMetadata -> {
             // skip exchanges that are explicitly disabled

--- a/src/main/java/com/r307/arbitrader/service/TradingScheduler.java
+++ b/src/main/java/com/r307/arbitrader/service/TradingScheduler.java
@@ -74,8 +74,8 @@ public class TradingScheduler {
     @PostConstruct
     public void connectExchanges() {
 
-        if (tradingConfiguration.getExitSpreadTarget() != null && tradingConfiguration.getMinimumProfit() != null)
-            throw new RuntimeException("Only one of exitSpreadTarget and minimumProfit configuration options is allowed.");
+        if (tradingConfiguration.getExitSpreadTarget() != null)
+            LOGGER.info("Property `exitSpreadTarget` is set, `minimumProfit` property setting will be ignored.");
 
         tradingConfiguration.getExchanges().forEach(exchangeMetadata -> {
             // skip exchanges that are explicitly disabled

--- a/src/main/java/com/r307/arbitrader/service/TradingScheduler.java
+++ b/src/main/java/com/r307/arbitrader/service/TradingScheduler.java
@@ -74,7 +74,7 @@ public class TradingScheduler {
     @PostConstruct
     public void connectExchanges() {
 
-        if (tradingConfiguration.getExitSpreadTarget() != null && tradingConfiguration.getEntrySpreadTarget() != null)
+        if (tradingConfiguration.getExitSpreadTarget() != null && tradingConfiguration.getMinimumProfit() != null)
             LOGGER.warn("Property `exitSpreadTarget` is set, `minimumProfit` property will be ignored.");
 
         tradingConfiguration.getExchanges().forEach(exchangeMetadata -> {

--- a/src/main/java/com/r307/arbitrader/service/TradingScheduler.java
+++ b/src/main/java/com/r307/arbitrader/service/TradingScheduler.java
@@ -21,6 +21,7 @@ import org.springframework.stereotype.Component;
 import javax.annotation.PostConstruct;
 import java.io.File;
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -222,12 +223,14 @@ public class TradingScheduler {
             }
 
             if (tradingService.getActivePosition() == null) {
+                final BigDecimal longFeePercent = exchangeService.getExchangeFee(spread.getLongExchange(), spread.getCurrencyPair(), true);
+                final BigDecimal shortFeePercent = exchangeService.getExchangeFee(spread.getShortExchange(), spread.getCurrencyPair(), true);
                 LOGGER.info("{}/{} {} {} -> {}",
                     spread.getLongExchange().getExchangeSpecification().getExchangeName(),
                     spread.getShortExchange().getExchangeSpecification().getExchangeName(),
                     spread.getCurrencyPair(),
                     spread.getIn(),
-                    tradingConfiguration.getEntrySpread());
+                    spreadService.getEntrySpreadTarget(tradingConfiguration, longFeePercent, shortFeePercent));
             } else if (tradingService.getActivePosition() != null
                 && tradingService.getActivePosition().getCurrencyPair().equals(spread.getCurrencyPair())
                 && tradingService.getActivePosition().getLongTrade().getExchange().equals(spread.getLongExchange().getExchangeSpecification().getExchangeName())

--- a/src/main/java/com/r307/arbitrader/service/TradingService.java
+++ b/src/main/java/com/r307/arbitrader/service/TradingService.java
@@ -107,15 +107,22 @@ public class TradingService {
             LOGGER.warn("Cannot alter position on one or more exchanges due to user configured blackout");
             return;
         }
-
+        final BigDecimal longFeePercent = exchangeService.getExchangeFee(spread.getLongExchange(), spread.getCurrencyPair(), true);
+        final BigDecimal shortFeePercent = exchangeService.getExchangeFee(spread.getShortExchange(), spread.getCurrencyPair(), true);
+        final BigDecimal entrySpreadTarget = spreadService.getEntrySpreadTarget(tradingConfiguration, longFeePercent, shortFeePercent);
         // This is more verbose than it has to be. I'm trying to keep it easy to read as we continue
         // adding more different conditions that can affect whether we trade or not.
         if (activePosition == null) {
             if (conditionService.isForceOpenCondition(spread.getCurrencyPair(), longExchangeName, shortExchangeName)) {
                 LOGGER.debug("enterPosition() {}/{} {} - forced", longExchangeName, shortExchangeName, spread.getCurrencyPair());
                 enterPosition(spread);
-            } else if (spread.getIn().compareTo(tradingConfiguration.getEntrySpread()) > 0) {
-                LOGGER.debug("enterPosition() {}/{} {} - spread in {} > entry spread {}", longExchangeName, shortExchangeName, spread.getCurrencyPair(), spread.getIn(), tradingConfiguration.getEntrySpread());
+            } else if (spread.getIn().compareTo(entrySpreadTarget) > 0) {
+                LOGGER.debug("enterPosition() {}/{} {} - spread in {} > entry spread target {}", longExchangeName, shortExchangeName, spread.getCurrencyPair(), spread.getIn(), entrySpreadTarget);
+                LOGGER.debug("entry spread target {} was calculated from the effective entry spread target {}, with {} long fees and {} short fees",
+                    entrySpreadTarget,
+                    tradingConfiguration.getEntrySpreadTarget(),
+                    longFeePercent,
+                    shortFeePercent);
                 enterPosition(spread);
             }
         } else if (spread.getCurrencyPair().equals(activePosition.getCurrencyPair())
@@ -151,7 +158,7 @@ public class TradingService {
         final BigDecimal shortFeePercent = exchangeService.getExchangeFee(spread.getShortExchange(), spread.getCurrencyPair(), true);
         final CurrencyPair currencyPairLongExchange = exchangeService.convertExchangePair(spread.getLongExchange(), spread.getCurrencyPair());
         final CurrencyPair currencyPairShortExchange = exchangeService.convertExchangePair(spread.getShortExchange(), spread.getCurrencyPair());
-        final BigDecimal exitTarget = spread.getIn().subtract(tradingConfiguration.getExitTarget());
+        final BigDecimal exitSpreadTarget = spreadService.getExitSpreadTarget(tradingConfiguration, spread.getIn(), longFeePercent, shortFeePercent);
         final BigDecimal maxExposure = getMaximumExposure(spread.getLongExchange(), spread.getShortExchange());
         final FeeComputation longFeeComputation = exchangeService.getExchangeMetadata(spread.getLongExchange()).getFeeComputation();
         final FeeComputation shortFeeComputation = exchangeService.getExchangeMetadata(spread.getShortExchange()).getFeeComputation();
@@ -186,7 +193,7 @@ public class TradingService {
         // figure out how much we want to trade
         EntryTradeVolume tradeVolume;
         try {
-            tradeVolume = TradeVolume.getEntryTradeVolume(longFeeComputation,shortFeeComputation,maxExposure,maxExposure,spread.getLongTicker().getAsk(),spread.getShortTicker().getBid(),longFeePercent,shortFeePercent, exitTarget, longScale, shortScale);
+            tradeVolume = TradeVolume.getEntryTradeVolume(longFeeComputation,shortFeeComputation,maxExposure,maxExposure,spread.getLongTicker().getAsk(),spread.getShortTicker().getBid(),longFeePercent,shortFeePercent, exitSpreadTarget, longScale, shortScale);
         } catch (IllegalArgumentException e) {
             LOGGER.error("Cannot instantiate order volumes, exiting trade.");
             return;
@@ -220,15 +227,16 @@ public class TradingService {
         BigDecimal spreadVerification = spreadService.computeSpread(longLimitPrice, shortLimitPrice);
         final boolean isForcedOpenCondition = conditionService.isForceOpenCondition(spread.getCurrencyPair(), longExchangeName, shortExchangeName);
 
-        if (!isForcedOpenCondition && spreadVerification.compareTo(tradingConfiguration.getEntrySpread()) < 0) {
-            LOGGER.debug("Spread verification is less than entry spread, will not trade"); // this is debug because it can get spammy
+        final BigDecimal entrySpreadTarget = spreadService.getEntrySpreadTarget(tradingConfiguration, longFeePercent, shortFeePercent);
+        if (!isForcedOpenCondition && spreadVerification.compareTo(entrySpreadTarget) < 0) {
+            LOGGER.debug("Spread verification {} is less than entry spread target {}, will not trade", spreadVerification, entrySpreadTarget); // this is debug because it can get spammy
             return;
         }
 
         if(longLimitPrice.compareTo(spread.getLongTicker().getAsk()) != 0 || shortLimitPrice.compareTo(spread.getShortTicker().getBid()) != 0) {
             //Adjust the volume after slip so the trade stays market neutral
             try {
-                tradeVolume = TradeVolume.getEntryTradeVolume(longFeeComputation, shortFeeComputation, maxExposure, maxExposure, longLimitPrice, shortLimitPrice, longFeePercent, shortFeePercent, exitTarget, longScale, shortScale);
+                tradeVolume = TradeVolume.getEntryTradeVolume(longFeeComputation, shortFeeComputation, maxExposure, maxExposure, longLimitPrice, shortLimitPrice, longFeePercent, shortFeePercent, exitSpreadTarget, longScale, shortScale);
             } catch (IllegalArgumentException e) {
                 LOGGER.error("Cannot instantiate order volumes, exiting trade.");
                 return;
@@ -257,7 +265,7 @@ public class TradingService {
             return;
         }
 
-        logEntryTrade(spread, shortExchangeName, longExchangeName, exitTarget, tradeVolume, longFeeComputation, shortFeeComputation, longLimitPrice, shortLimitPrice, isForcedOpenCondition);
+        logEntryTrade(spread, shortExchangeName, longExchangeName, exitSpreadTarget, tradeVolume, longFeeComputation, shortFeeComputation, longLimitPrice, shortLimitPrice, isForcedOpenCondition);
 
         BigDecimal totalBalance = logCurrentExchangeBalances(spread.getLongExchange(), spread.getShortExchange());
 
@@ -265,7 +273,7 @@ public class TradingService {
             activePosition = new ActivePosition();
             activePosition.setEntryTime(OffsetDateTime.now());
             activePosition.setCurrencyPair(spread.getCurrencyPair());
-            activePosition.setExitTarget(exitTarget);
+            activePosition.setExitTarget(exitSpreadTarget);
             activePosition.setEntryBalance(totalBalance);
             activePosition.getLongTrade().setExchange(spread.getLongExchange());
             activePosition.getLongTrade().setVolume(tradeVolume.getLongOrderVolume());
@@ -281,7 +289,7 @@ public class TradingService {
                 tradeVolume.getLongOrderVolume(), tradeVolume.getShortOrderVolume(),
                 true);
 
-            notificationService.sendEntryTradeNotification(spread, exitTarget, tradeVolume,
+            notificationService.sendEntryTradeNotification(spread, exitSpreadTarget, tradeVolume,
                 longLimitPrice, shortLimitPrice, isForcedOpenCondition);
         } catch (IOException e) {
             LOGGER.error("IOE executing limit orders: ", e);
@@ -419,7 +427,8 @@ public class TradingService {
         //
         // Also, don't spam the logs with this warning. It's possible that this condition could last for awhile
         // and this code could be executed frequently.
-        if (isActivePositionExpired() && spreadVerification.compareTo(tradingConfiguration.getEntrySpread()) < 0) {
+        final BigDecimal entrySpreadTarget = spreadService.getEntrySpreadTarget(tradingConfiguration, longFeePercent, shortFeePercent);
+        if (isActivePositionExpired() && spreadVerification.compareTo(entrySpreadTarget) < 0) {
             if (!timeoutExitWarning) {
                 LOGGER.warn("Timeout exit triggered");
                 LOGGER.warn("Cannot exit now because spread would cause immediate reentry");

--- a/src/test/java/com/r307/arbitrader/service/SpreadServiceTest.java
+++ b/src/test/java/com/r307/arbitrader/service/SpreadServiceTest.java
@@ -12,6 +12,7 @@ import org.mockito.Mock;
 
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 
 import static org.junit.Assert.assertEquals;
 
@@ -188,5 +189,43 @@ public class SpreadServiceTest extends BaseTestCase {
 
         spreadService.publish(spread);
         spreadService.summary();
+    }
+
+    @Test
+    public void testGetEntrySpreadTarget() {
+        TradingConfiguration tradingConfiguration = new TradingConfiguration();
+        tradingConfiguration.setEntrySpreadTarget(new BigDecimal("0.001"));
+        BigDecimal longFee = new BigDecimal("0.005");
+        BigDecimal shortFee = new BigDecimal("0.0026");
+
+        BigDecimal entrySpreadTarget = spreadService.getEntrySpreadTarget(tradingConfiguration, longFee, shortFee);
+        assertEquals(new BigDecimal("0.008627431321436").setScale(8, RoundingMode.HALF_EVEN), entrySpreadTarget.setScale(8, RoundingMode.HALF_EVEN));
+    }
+
+    @Test
+    public void testGetExitSpreadTarget_fromProfit() {
+        TradingConfiguration tradingConfiguration = new TradingConfiguration();
+        tradingConfiguration.setMinimumProfit(new BigDecimal("0.001"));
+        BigDecimal longFee = new BigDecimal("0.005");
+        BigDecimal shortFee = new BigDecimal("0.0026");
+        BigDecimal entrySpread = new BigDecimal("0.008627431321436");
+
+        BigDecimal exitSpreadTarget = spreadService.getExitSpreadTarget(tradingConfiguration, entrySpread, longFee, shortFee);
+        assertEquals(new BigDecimal("-0.007580291242769").setScale(8, RoundingMode.HALF_EVEN), exitSpreadTarget.setScale(8, RoundingMode.HALF_EVEN));
+
+    }
+
+    @Test
+    public void testGetExitSpreadTarget_fromSpreadTarget() {
+        TradingConfiguration tradingConfiguration = new TradingConfiguration();
+        tradingConfiguration.setExitSpreadTarget(new BigDecimal("0.001"));
+        BigDecimal longFee = new BigDecimal("0.005");
+        BigDecimal shortFee = new BigDecimal("0.0026");
+        BigDecimal entrySpread = new BigDecimal("0.008627431321436");
+
+        BigDecimal exitSpreadTarget = spreadService.getExitSpreadTarget(tradingConfiguration, entrySpread, longFee, shortFee);
+
+        assertEquals(new BigDecimal("-0.006587871534012").setScale(8, RoundingMode.HALF_EVEN), exitSpreadTarget.setScale(8, RoundingMode.HALF_EVEN));
+
     }
 }


### PR DESCRIPTION
This changes the configuration from entrySpread / exitTarget to:
- entrySpreadTarget: the effective spread to meet before entering a trade
- exitSpreadTarget: the effective spread to meet before closing a trade
- minimumProfit: the profit in percentage to get before closing a trade. Default to 0.
If exitSpreadTarget is set, the minimumProfit property is ignored. 

We calculate the real entry and exit spread targets from those configurations.