### PR TITLE
configurable minimum balances

### DIFF
--- a/application.example.yaml
+++ b/application.example.yaml
@@ -181,6 +181,7 @@ trading:
       # The amount of fees Kraken charges. If an exchange's API supports requesting fees at runtime, the bot
       # will use that value instead. If not, it will fall back to the configured value.
       fee: 0.0026
+
       # Enable (value set to true) or disable (value set to false) this exchange. If 'active' configuration is not set
       # then, by default, the exchange is set as active
       active: true
@@ -214,7 +215,6 @@ trading:
         - NEO/USD
         - ONT/USD
         - DASH/USD
-      fee: 0.0010
 
     -
       exchangeClass: org.knowm.xchange.bitflyer.BitflyerExchange
@@ -226,6 +226,17 @@ trading:
       port: 443
       tradingPairs:
         - BTC/USD
+
+      # Arbitrader won't start if your account has a crypto balance greater than the minimum trade size for the
+      # exchange. Unfortunately the metadata XChange has about the minimum trade sizes on exchanges is not always
+      # correct, and sometimes it's missing entirely. This is an option to provide your own value as a map of
+      # currency pairs to allowed account balances. If your account balance in the specified currency pair is less
+      # than the value provided here, the bot will start up and could potentially sell some of this balance.
+      #
+      # This configuration is your way out if you're stuck with 0.00000001 BTC that you can't seem to get rid of
+      # but the bot refuses to start up because the balance isn't _exactly_ zero.
+      minBalanceOverride:
+        BTC/USD: 0.001
 
       # BitFlyer doesn't support margin trading (for US based customers, anyway).
       margin: false

--- a/application.example.yaml
+++ b/application.example.yaml
@@ -215,6 +215,7 @@ trading:
         - NEO/USD
         - ONT/USD
         - DASH/USD
+      fee: 0.0010
 
     -
       exchangeClass: org.knowm.xchange.bitflyer.BitflyerExchange

--- a/src/main/java/com/r307/arbitrader/config/ExchangeConfiguration.java
+++ b/src/main/java/com/r307/arbitrader/config/ExchangeConfiguration.java
@@ -4,10 +4,7 @@ import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
 
 import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static com.r307.arbitrader.config.FeeComputation.SERVER;
 
@@ -26,6 +23,7 @@ public class ExchangeConfiguration {
     private Integer port;
     private Map<String, String> custom = new HashMap<>();
     private List<CurrencyPair> tradingPairs = new ArrayList<>();
+    private Map<String, BigDecimal> minBalanceOverride = new HashMap<>();
     private Boolean margin;
     private List<CurrencyPair> marginExclude = new ArrayList<>();
     private BigDecimal fee;
@@ -106,6 +104,14 @@ public class ExchangeConfiguration {
 
     public void setTradingPairs(List<CurrencyPair> tradingPairs) {
         this.tradingPairs = tradingPairs;
+    }
+
+    public Optional<BigDecimal> getMinBalanceOverride(CurrencyPair currencyPair) {
+        return Optional.ofNullable(minBalanceOverride.get(currencyPair.base.toString() + currencyPair.counter.toString()));
+    }
+
+    public void setMinBalanceOverride(Map<String, BigDecimal> minBalanceOverride) {
+        this.minBalanceOverride = minBalanceOverride;
     }
 
     public Boolean getMargin() {

--- a/src/main/java/com/r307/arbitrader/service/ExchangeService.java
+++ b/src/main/java/com/r307/arbitrader/service/ExchangeService.java
@@ -275,8 +275,6 @@ public class ExchangeService {
                         minimumAmount);
                 }
 
-                LOGGER.debug("{} {} min amount: {}", exchange.getExchangeSpecification().getExchangeName(), pair, minimumAmount);
-
                 return currencyBalanceEntry.getValue().getAvailable().compareTo(minimumAmount) > 0;
             })
             .map(currencyBalanceEntry -> currencyBalanceEntry.getKey().getCurrencyCode())

--- a/src/main/java/com/r307/arbitrader/service/ExchangeService.java
+++ b/src/main/java/com/r307/arbitrader/service/ExchangeService.java
@@ -220,13 +220,18 @@ public class ExchangeService {
 
     /**
      * By using the configured trading pairs for the given exchange, get the list of crypto currencies where the wallet
-     * is not empty. The {@link Exchange} home currency is not taken in consideration, it is ignored.
-     * @param exchange
+     * has more than the minimum trade size in currency. The {@link Exchange} home currency is ignored. This check is used
+     * to determine if the accounts are in a valid state for the bot to start up: all balances need to be in the fiat
+     * currency so that we avoid disrupting any existing positions or inadvertently selling off any of the user's
+     * crypto balances that the bot didn't buy.
+     *
+     * @param exchange The exchange to return current balances for.
      * @return A {@link Set} containing the currency code
-     * @throws IOException
+     * @throws IOException If we can't request account info from the exchange.
      */
     public Set<String> getCryptoCoinsFromTradingPairs(Exchange exchange) throws IOException {
         final List<CurrencyPair> tradingPairs = getExchangeMetadata(exchange).getTradingPairs();
+        final Currency homeCurrency = getExchangeHomeCurrency(exchange);
 
         // Get all account currencies where the wallet balance is not empty
         final Set<String> accountCurrencies = exchange.getAccountService()
@@ -235,8 +240,18 @@ public class ExchangeService {
             .values()
             .stream()
             .flatMap(wallet -> wallet.getBalances().entrySet().stream())
-            .filter(currencyBalanceEntry -> currencyBalanceEntry.getKey() != getExchangeMetadata(exchange).getHomeCurrency())
-            .filter(currencyBalanceEntry -> currencyBalanceEntry.getValue().getAvailable().compareTo(BigDecimal.ZERO) > 0)
+            .filter(currencyBalanceEntry -> currencyBalanceEntry.getKey() != homeCurrency)
+            .filter(currencyBalanceEntry -> {
+                CurrencyPair pair = new CurrencyPair(currencyBalanceEntry.getValue().getCurrency(), homeCurrency);
+                Optional<CurrencyPairMetaData> metaDataOptional = Optional.ofNullable(exchange
+                    .getExchangeMetaData()
+                    .getCurrencyPairs()
+                    .get(pair));
+
+                BigDecimal minimumAmount = metaDataOptional.isPresent() ? metaDataOptional.get().getMinimumAmount() : BigDecimal.ZERO;
+
+                return currencyBalanceEntry.getValue().getAvailable().compareTo(minimumAmount) > 0;
+            })
             .map(currencyBalanceEntry -> currencyBalanceEntry.getKey().getCurrencyCode())
             .collect(Collectors.toSet());
 


### PR DESCRIPTION
The feature to prevent Arbitrader from starting if an account has a non-zero crypto balance in it was a good idea but it led me into an impossible situation: my BitFlyer account has 0.00000001 BTC in it, and BitFlyer's minimum trade size is 0.001. I've tried buying crypto and selling all of it to get down to zero and no matter what I do that one last little satoshi remains.

So... I tried making it look at the exchange metadata to figure out the minimum trade size and compare against that instead of zero. Of course the metadata for BitFlyer is missing, so it defaults to zero.

So here we are. I have added a new configuration option that lets you set the minimum allowed balance for a currency on an exchange to whatever you want if the bot won't start because of a tiny bit of crypto you can't seem to get rid of.