### PR TITLE
Use the CurrencyPairMetaData to find the price scale

### DIFF
--- a/src/main/java/com/r307/arbitrader/service/TradingService.java
+++ b/src/main/java/com/r307/arbitrader/service/TradingService.java
@@ -330,6 +330,11 @@ public class TradingService {
             defaultPairMetaData
         );
 
+        if (currencyPairMetaData.getVolumeScale() == null) {
+            LOGGER.debug("Defaulting to scale of {} for volume because metadata is unavailable", BTC_SCALE);
+            return BTC_SCALE;
+        }
+
         return currencyPairMetaData.getVolumeScale();
     }
 
@@ -356,6 +361,11 @@ public class TradingService {
             currencyPair,
             defaultPairMetaData
         );
+
+        if (currencyPairMetaData.getPriceScale() == null) {
+            LOGGER.debug("Defaulting to scale of {} for price because metadata is unavailable", USD_SCALE);
+            return USD_SCALE;
+        }
 
         return currencyPairMetaData.getPriceScale();
     }

--- a/src/test/java/com/r307/arbitrader/ExchangeBuilder.java
+++ b/src/test/java/com/r307/arbitrader/ExchangeBuilder.java
@@ -44,7 +44,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class ExchangeBuilder {
-    public static final int EXCHANGE_METADATA_PRICE_SCALE = 4; // intentionally different than BTC_SCALE to help with assertions
+    public static final int EXCHANGE_METADATA_PRICE_SCALE = 3; // intentionally different than BTC_SCALE to help with assertions
+    public static final int EXCHANGE_METADATA_VOLUME_SCALE = 4; // intentionally different than BTC_SCALE to help with assertions
 
     private String name;
     private CurrencyPair currencyPair;
@@ -131,8 +132,9 @@ public class ExchangeBuilder {
             new BigDecimal("0.0010"),
             new BigDecimal("1000.00000000"),
             EXCHANGE_METADATA_PRICE_SCALE,
+            EXCHANGE_METADATA_VOLUME_SCALE,
             null,
-            null);
+            Currency.USD);
         Map<CurrencyPair, CurrencyPairMetaData> currencyPairMetaDataMap = new HashMap<>();
 
         currencyPairMetaDataMap.put(currencyPair, currencyPairMetaData);

--- a/src/test/java/com/r307/arbitrader/ExchangeBuilder.java
+++ b/src/test/java/com/r307/arbitrader/ExchangeBuilder.java
@@ -44,6 +44,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class ExchangeBuilder {
+    public static final int EXCHANGE_METADATA_PRICE_SCALE = 4; // intentionally different than BTC_SCALE to help with assertions
+
     private String name;
     private CurrencyPair currencyPair;
     private Currency homeCurrency = Currency.USD;
@@ -128,7 +130,7 @@ public class ExchangeBuilder {
             new BigDecimal("0.0020"),
             new BigDecimal("0.0010"),
             new BigDecimal("1000.00000000"),
-            BTC_SCALE,
+            EXCHANGE_METADATA_PRICE_SCALE,
             null,
             null);
         Map<CurrencyPair, CurrencyPairMetaData> currencyPairMetaDataMap = new HashMap<>();

--- a/src/test/java/com/r307/arbitrader/service/TradingServiceTest.java
+++ b/src/test/java/com/r307/arbitrader/service/TradingServiceTest.java
@@ -8,7 +8,6 @@ import com.r307.arbitrader.config.NotificationConfiguration;
 import com.r307.arbitrader.exception.OrderNotFoundException;
 import com.r307.arbitrader.config.TradingConfiguration;
 import com.r307.arbitrader.service.model.ArbitrageLog;
-import com.r307.arbitrader.service.model.ExchangeFee;
 import com.r307.arbitrader.service.telegram.TelegramClient;
 import org.apache.commons.io.FileUtils;
 import org.junit.Before;
@@ -31,6 +30,7 @@ import java.util.List;
 import static com.r307.arbitrader.DecimalConstants.BTC_SCALE;
 import static com.r307.arbitrader.DecimalConstants.USD_SCALE;
 import static com.r307.arbitrader.ExchangeBuilder.EXCHANGE_METADATA_PRICE_SCALE;
+import static com.r307.arbitrader.ExchangeBuilder.EXCHANGE_METADATA_VOLUME_SCALE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.*;
@@ -210,7 +210,7 @@ public class TradingServiceTest extends BaseTestCase {
         BigDecimal allowedVolume = new BigDecimal("1.00");
         BigDecimal limitPrice = tradingService.getLimitPrice(longExchange, currencyPair, allowedVolume, Order.OrderType.ASK);
 
-        assertEquals(new BigDecimal("100.0000").setScale(BTC_SCALE, RoundingMode.HALF_EVEN), limitPrice);
+        assertEquals(new BigDecimal("100.000").setScale(EXCHANGE_METADATA_PRICE_SCALE, RoundingMode.HALF_EVEN), limitPrice);
     }
 
     // the best price point has enough volume to fill my order
@@ -222,7 +222,7 @@ public class TradingServiceTest extends BaseTestCase {
         BigDecimal allowedVolume = new BigDecimal("1.00");
         BigDecimal limitPrice = tradingService.getLimitPrice(longExchange, currencyPair, allowedVolume, Order.OrderType.BID);
 
-        assertEquals(new BigDecimal("100.0990").setScale(BTC_SCALE, RoundingMode.HALF_EVEN), limitPrice);
+        assertEquals(new BigDecimal("100.099").setScale(EXCHANGE_METADATA_PRICE_SCALE, RoundingMode.HALF_EVEN), limitPrice);
     }
 
     // the best price point isn't big enough to fill my order alone, so the price will slip
@@ -233,7 +233,7 @@ public class TradingServiceTest extends BaseTestCase {
         BigDecimal allowedVolume = new BigDecimal("11.00");
         BigDecimal limitPrice = tradingService.getLimitPrice(longExchange, currencyPair, allowedVolume, Order.OrderType.ASK);
 
-        assertEquals(new BigDecimal("100.0010").setScale(BTC_SCALE, RoundingMode.HALF_EVEN), limitPrice);
+        assertEquals(new BigDecimal("100.001").setScale(EXCHANGE_METADATA_PRICE_SCALE, RoundingMode.HALF_EVEN), limitPrice);
     }
 
     // the best price point isn't big enough to fill my order alone, so the price will slip
@@ -244,7 +244,7 @@ public class TradingServiceTest extends BaseTestCase {
         BigDecimal allowedVolume = new BigDecimal("11.00");
         BigDecimal limitPrice = tradingService.getLimitPrice(longExchange, currencyPair, allowedVolume, Order.OrderType.BID);
 
-        assertEquals(new BigDecimal("100.0980").setScale(BTC_SCALE, RoundingMode.HALF_EVEN), limitPrice);
+        assertEquals(new BigDecimal("100.098").setScale(EXCHANGE_METADATA_PRICE_SCALE, RoundingMode.HALF_EVEN), limitPrice);
     }
 
     // the exchange doesn't have enough volume to fill my gigantic order
@@ -264,19 +264,31 @@ public class TradingServiceTest extends BaseTestCase {
     }
 
     @Test
+    public void testComputeVolumeScale() {
+        Integer result = tradingService.computeVolumeScale(longExchange, CurrencyPair.BTC_USD);
+
+        assertEquals(Integer.valueOf(EXCHANGE_METADATA_VOLUME_SCALE), result);
+    }
+
+    @Test
+    public void testComputeVolumeScaleDefault() {
+        Integer result = tradingService.computeVolumeScale(longExchange, CurrencyPair.LTC_USD);
+
+        assertEquals(Integer.valueOf(BTC_SCALE), result);
+    }
+
+    @Test
     public void testComputePriceScale() {
-        ExchangeFee fee = new ExchangeFee(new BigDecimal("0.0026"), null);
-        Integer result = tradingService.computePriceScale(longExchange, fee, CurrencyPair.BTC_USD);
+        Integer result = tradingService.computePriceScale(longExchange, CurrencyPair.BTC_USD);
 
         assertEquals(Integer.valueOf(EXCHANGE_METADATA_PRICE_SCALE), result);
     }
 
     @Test
     public void testComputePriceScaleDefault() {
-        ExchangeFee fee = new ExchangeFee(new BigDecimal("0.0026"), null);
-        Integer result = tradingService.computePriceScale(longExchange, fee, CurrencyPair.LTC_USD);
+        Integer result = tradingService.computePriceScale(longExchange, CurrencyPair.BTC_USD);
 
-        assertEquals(Integer.valueOf(BTC_SCALE), result);
+        assertEquals(Integer.valueOf(EXCHANGE_METADATA_PRICE_SCALE), result);
     }
 
     @Test

--- a/src/test/java/com/r307/arbitrader/service/TradingServiceTest.java
+++ b/src/test/java/com/r307/arbitrader/service/TradingServiceTest.java
@@ -8,6 +8,7 @@ import com.r307.arbitrader.config.NotificationConfiguration;
 import com.r307.arbitrader.exception.OrderNotFoundException;
 import com.r307.arbitrader.config.TradingConfiguration;
 import com.r307.arbitrader.service.model.ArbitrageLog;
+import com.r307.arbitrader.service.model.ExchangeFee;
 import com.r307.arbitrader.service.telegram.TelegramClient;
 import org.apache.commons.io.FileUtils;
 import org.junit.Before;
@@ -29,6 +30,7 @@ import java.util.List;
 
 import static com.r307.arbitrader.DecimalConstants.BTC_SCALE;
 import static com.r307.arbitrader.DecimalConstants.USD_SCALE;
+import static com.r307.arbitrader.ExchangeBuilder.EXCHANGE_METADATA_PRICE_SCALE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.*;
@@ -259,6 +261,22 @@ public class TradingServiceTest extends BaseTestCase {
         BigDecimal allowedVolume = new BigDecimal(10001);
 
         tradingService.getLimitPrice(longExchange, currencyPair, allowedVolume, Order.OrderType.BID);
+    }
+
+    @Test
+    public void testComputePriceScale() {
+        ExchangeFee fee = new ExchangeFee(new BigDecimal("0.0026"), null);
+        Integer result = tradingService.computePriceScale(longExchange, fee, CurrencyPair.BTC_USD);
+
+        assertEquals(Integer.valueOf(EXCHANGE_METADATA_PRICE_SCALE), result);
+    }
+
+    @Test
+    public void testComputePriceScaleDefault() {
+        ExchangeFee fee = new ExchangeFee(new BigDecimal("0.0026"), null);
+        Integer result = tradingService.computePriceScale(longExchange, fee, CurrencyPair.LTC_USD);
+
+        assertEquals(Integer.valueOf(BTC_SCALE), result);
     }
 
     @Test


### PR DESCRIPTION
 ...instead of the CurrencyMetaData which seems to have the wrong values for what we're doing.

This is intended to fix errors that have started to pop up with Kraken saying that we're using the wrong number of decimal places for several currency pairs.