### PR TITLE
Prevent the bot from starting if an exchange account balance is lower than the defined fixed exposure

### DIFF
--- a/src/main/java/com/r307/arbitrader/service/TradingScheduler.java
+++ b/src/main/java/com/r307/arbitrader/service/TradingScheduler.java
@@ -157,7 +157,7 @@ public class TradingScheduler {
         });
 
         // call setUpExchange on every exchange
-        exchanges.forEach(exchangeService::setUpExchange);
+        exchanges.forEach(exchange -> exchangeService.setUpExchange(exchange, tradingConfiguration));
 
         // set up all the valid TradeCombinations between all our exchanges so we know what currency pairs we can trade
         tickerService.initializeTickers(exchanges);


### PR DESCRIPTION
Prevent the bot from starting if the user set a fixed exposure and the account balance is lower than the defined fixed exposure.
Otherwise the bot will start and then get a `Not Enough Balance` exception on the first trade it tries to execute on that exchange.