### PR TITLE
Null check CurrencyPairMetaData.getMinimumAmount() - for some currency pairs it may be null

### DIFF
--- a/src/main/java/com/r307/arbitrader/service/ExchangeService.java
+++ b/src/main/java/com/r307/arbitrader/service/ExchangeService.java
@@ -279,7 +279,7 @@ public class ExchangeService {
                         exchange.getExchangeSpecification().getExchangeName(),
                         pair,
                         minimumAmount);
-                } else if (metaDataOptional.isPresent()) {
+                } else if (metaDataOptional.isPresent() && metaDataOptional.get().getMinimumAmount() != null) {
                     minimumAmount = metaDataOptional.get().getMinimumAmount();
 
                     LOGGER.debug("{} using exchange metadata for minimum balance: {} = {}",


### PR DESCRIPTION
For some reason I started to get a NPE on start up for some coins on Bitstamp exchange. This should fix it