### PR TITLE
small changes to aid upcoming performance optimization

### DIFF
--- a/src/main/java/com/r307/arbitrader/DecimalConstants.java
+++ b/src/main/java/com/r307/arbitrader/DecimalConstants.java
@@ -1,6 +1,7 @@
 package com.r307.arbitrader;
 
 public final class DecimalConstants {
+    public static final int SAFE_SCALE = 1; // really conservative, safe default scale
     public static final int USD_SCALE = 2;
     public static final int BTC_SCALE = 8;
 

--- a/src/test/java/com/r307/arbitrader/service/TradingServiceTest.java
+++ b/src/test/java/com/r307/arbitrader/service/TradingServiceTest.java
@@ -265,30 +265,30 @@ public class TradingServiceTest extends BaseTestCase {
 
     @Test
     public void testComputeVolumeScale() {
-        Integer result = tradingService.computeVolumeScale(longExchange, CurrencyPair.BTC_USD);
+        Integer result = tradingService.computeVolumeScale(longExchange, CurrencyPair.BTC_USD, BTC_SCALE);
 
         assertEquals(Integer.valueOf(EXCHANGE_METADATA_VOLUME_SCALE), result);
     }
 
     @Test
     public void testComputeVolumeScaleDefault() {
-        Integer result = tradingService.computeVolumeScale(longExchange, CurrencyPair.LTC_USD);
+        Integer result = tradingService.computeVolumeScale(longExchange, CurrencyPair.LTC_USD, BTC_SCALE);
 
         assertEquals(Integer.valueOf(BTC_SCALE), result);
     }
 
     @Test
     public void testComputePriceScale() {
-        Integer result = tradingService.computePriceScale(longExchange, CurrencyPair.BTC_USD);
+        Integer result = tradingService.computePriceScale(longExchange, CurrencyPair.BTC_USD, USD_SCALE);
 
         assertEquals(Integer.valueOf(EXCHANGE_METADATA_PRICE_SCALE), result);
     }
 
     @Test
     public void testComputePriceScaleDefault() {
-        Integer result = tradingService.computePriceScale(longExchange, CurrencyPair.BTC_USD);
+        Integer result = tradingService.computePriceScale(longExchange, CurrencyPair.LTC_USD, USD_SCALE);
 
-        assertEquals(Integer.valueOf(EXCHANGE_METADATA_PRICE_SCALE), result);
+        assertEquals(Integer.valueOf(USD_SCALE), result);
     }
 
     @Test


### PR DESCRIPTION
* timers for order execution and decision making to help us improve performance
* changed `computeVolumeScale()` and `computePriceScale()` to use a provided default value for added flexibility
* changed `computeVolumeScale()` and `computePriceScale()` to avoid unnecessary object creation
* changed `computeVolumeScale()` and `computePriceScale()` to log when metadata is not available
* some additional logging