### PR TITLE
temporarily remove dependabot badge because it's broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Arbitrader
-![AWS CodeBuild](https://codebuild.us-west-2.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiUnhycTV0MEFLb293K1Y0QlBjOUxESnBaWXM3V3BLMGhEU2Zjcm0yWHpnRGhFdmxYWm45M2dqVU1ZUjRSdldhR0NsUEYyWk0xVWJZUVZBUXhGZmJUZjhrPSIsIml2UGFyYW1ldGVyU3BlYyI6InNER0tuUnhKQ0pUMVhTUVAiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
-[![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=agonyforge/arbitrader)](https://dependabot.com)    
+![AWS CodeBuild](https://codebuild.us-west-2.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiUnhycTV0MEFLb293K1Y0QlBjOUxESnBaWXM3V3BLMGhEU2Zjcm0yWHpnRGhFdmxYWm45M2dqVU1ZUjRSdldhR0NsUEYyWk0xVWJZUVZBUXhGZmJUZjhrPSIsIml2UGFyYW1ldGVyU3BlYyI6InNER0tuUnhKQ0pUMVhTUVAiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)  
 [![Discord](https://img.shields.io/discord/767482695323222036?logo=Discord)](https://discord.gg/ZYmG3Nw)
 [![Ko-fi Blog](https://img.shields.io/badge/Blog-Ko--fi-informational?logo=Ko-fi)](https://ko-fi.com/scionaltera)  
 **A market neutral cryptocurrency trading bot.**


### PR DESCRIPTION
See https://github.com/dependabot/dependabot-core/issues/1912

Will add it back in when the new Dependabot supports a badge.