### PR TITLE
invalidate tickers where price is exactly equal to zero

### DIFF
--- a/src/main/java/com/agonyforge/arbitrader/service/TickerService.java
+++ b/src/main/java/com/agonyforge/arbitrader/service/TickerService.java
@@ -167,7 +167,7 @@ public class TickerService {
     public boolean isInvalidTicker(Ticker ticker) {
         return ticker == null
             || ticker.getBid() == null || ticker.getAsk() == null
-            || ticker.getBid().equals(BigDecimal.ZERO) || ticker.getAsk().equals(BigDecimal.ZERO);
+            || ticker.getBid().compareTo(BigDecimal.ZERO) == 0 || ticker.getAsk().compareTo(BigDecimal.ZERO) == 0;
     }
 
     /**

--- a/src/main/java/com/agonyforge/arbitrader/service/TickerService.java
+++ b/src/main/java/com/agonyforge/arbitrader/service/TickerService.java
@@ -13,6 +13,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import javax.inject.Inject;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -164,7 +165,9 @@ public class TickerService {
      * @return true if the Ticker is missing required fields.
      */
     public boolean isInvalidTicker(Ticker ticker) {
-        return ticker == null || ticker.getBid() == null || ticker.getAsk() == null;
+        return ticker == null
+            || ticker.getBid() == null || ticker.getAsk() == null
+            || ticker.getBid().equals(BigDecimal.ZERO) || ticker.getAsk().equals(BigDecimal.ZERO);
     }
 
     /**

--- a/src/test/java/com/agonyforge/arbitrader/service/SpreadServiceTest.java
+++ b/src/test/java/com/agonyforge/arbitrader/service/SpreadServiceTest.java
@@ -199,7 +199,7 @@ public class SpreadServiceTest extends BaseTestCase {
 
         BigDecimal spread = spreadService.computeSpread(longPrice, shortPrice);
 
-        assertEquals(new BigDecimal("0.50000000"), spread);
+        assertEquals(0, new BigDecimal("0.50000000").compareTo(spread));
     }
 
     @Test

--- a/src/test/java/com/agonyforge/arbitrader/service/SpreadServiceTest.java
+++ b/src/test/java/com/agonyforge/arbitrader/service/SpreadServiceTest.java
@@ -193,6 +193,16 @@ public class SpreadServiceTest extends BaseTestCase {
     }
 
     @Test
+    public void testComputeSpread() {
+        BigDecimal longPrice = new BigDecimal("10.00000000");
+        BigDecimal shortPrice = new BigDecimal("15.00000000");
+
+        BigDecimal spread = spreadService.computeSpread(longPrice, shortPrice);
+
+        assertEquals(new BigDecimal("0.50000000"), spread);
+    }
+
+    @Test
     public void testGetEntrySpreadTarget() {
         TradingConfiguration tradingConfiguration = new TradingConfiguration();
         tradingConfiguration.setEntrySpreadTarget(new BigDecimal("0.001"));

--- a/src/test/java/com/agonyforge/arbitrader/service/TickerServiceTest.java
+++ b/src/test/java/com/agonyforge/arbitrader/service/TickerServiceTest.java
@@ -166,6 +166,26 @@ public class TickerServiceTest {
     }
 
     @Test
+    public void testIsInvalidTickerZeroBid() {
+        Ticker ticker = new Ticker.Builder()
+            .bid(new BigDecimal("0"))
+            .ask(new BigDecimal("64000.00000000"))
+            .build();
+
+        assertTrue(tickerService.isInvalidTicker(ticker));
+    }
+
+    @Test
+    public void testIsInvalidTickerZeroAsk() {
+        Ticker ticker = new Ticker.Builder()
+            .bid(new BigDecimal("64000.00000000"))
+            .ask(new BigDecimal("0"))
+            .build();
+
+        assertTrue(tickerService.isInvalidTicker(ticker));
+    }
+
+    @Test
     public void testIsInvalidTicker() {
         Ticker ticker = new Ticker.Builder()
             .bid(new BigDecimal("120.00"))


### PR DESCRIPTION
These are much more likely to be an API error of some kind rather than the exchange buying or selling coins for free.

Fixes #507 