### PR TITLE
Liquidity error handling

### DIFF
--- a/src/main/java/com/agonyforge/arbitrader/service/LiquidityException.java
+++ b/src/main/java/com/agonyforge/arbitrader/service/LiquidityException.java
@@ -1,0 +1,10 @@
+package com.agonyforge.arbitrader.service;
+
+/**
+ * Thrown when an exchange has too little liquidity for us to place the order we want.
+ */
+public class LiquidityException extends RuntimeException {
+    public LiquidityException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/agonyforge/arbitrader/service/TradingService.java
+++ b/src/main/java/com/agonyforge/arbitrader/service/TradingService.java
@@ -956,8 +956,22 @@ public class TradingService {
             // If we set our limit order at this price (without waiting too long) it is very likely to fill
             // because we know the exchange has enough currency available to fill it at this or a better price.
             for (LimitOrder order : orders) {
+                LOGGER.info("{} order {} remaining amount: {}",
+                    exchange.getExchangeSpecification().getExchangeName(),
+                    order.getId(),
+                    order.getRemainingAmount());
+                LOGGER.info("{} order {} original amount: {}",
+                    exchange.getExchangeSpecification().getExchangeName(),
+                    order.getId(),
+                    order.getOriginalAmount());
+
                 price = order.getLimitPrice();
-                volume = volume.add(order.getRemainingAmount());
+
+                if (order.getRemainingAmount() == null || BigDecimal.ZERO.compareTo(order.getRemainingAmount()) == 0) {
+                    volume = volume.add(order.getOriginalAmount());
+                } else{
+                    volume = volume.add(order.getRemainingAmount());
+                }
 
                 if (volume.compareTo(allowedVolume) > 0) {
                     int scale = computePriceScale(exchange, currencyPair);

--- a/src/test/java/com/agonyforge/arbitrader/service/TradingServiceTest.java
+++ b/src/test/java/com/agonyforge/arbitrader/service/TradingServiceTest.java
@@ -201,7 +201,7 @@ public class TradingServiceTest extends BaseTestCase {
 
     // the best price point has enough volume to fill my order
     @Test
-    public void testLimitPriceLongSufficientVolume() {
+    public void testLimitPriceLongSufficientVolume() throws IOException {
         when(exchangeService.convertExchangePair(any(Exchange.class), any(CurrencyPair.class)))
             .thenReturn(currencyPair);
 
@@ -213,7 +213,7 @@ public class TradingServiceTest extends BaseTestCase {
 
     // the best price point has enough volume to fill my order
     @Test
-    public void testLimitPriceShortSufficientVolume() {
+    public void testLimitPriceShortSufficientVolume() throws IOException {
         when(exchangeService.convertExchangePair(any(Exchange.class), any(CurrencyPair.class)))
             .thenReturn(currencyPair);
 
@@ -225,7 +225,7 @@ public class TradingServiceTest extends BaseTestCase {
 
     // the best price point isn't big enough to fill my order alone, so the price will slip
     @Test
-    public void testLimitPriceLongInsufficientVolume() {
+    public void testLimitPriceLongInsufficientVolume() throws IOException {
         when(exchangeService.convertExchangePair(any(Exchange.class), any(CurrencyPair.class)))
             .thenReturn(currencyPair);
         BigDecimal allowedVolume = new BigDecimal("11.00");
@@ -236,7 +236,7 @@ public class TradingServiceTest extends BaseTestCase {
 
     // the best price point isn't big enough to fill my order alone, so the price will slip
     @Test
-    public void testLimitPriceShortInsufficientVolume() {
+    public void testLimitPriceShortInsufficientVolume() throws IOException {
         when(exchangeService.convertExchangePair(any(Exchange.class), any(CurrencyPair.class)))
             .thenReturn(currencyPair);
         BigDecimal allowedVolume = new BigDecimal("11.00");
@@ -247,7 +247,7 @@ public class TradingServiceTest extends BaseTestCase {
 
     // the exchange doesn't have enough volume to fill my gigantic order
     @Test(expected = RuntimeException.class)
-    public void testLimitPriceLongInsufficientLiquidity() {
+    public void testLimitPriceLongInsufficientLiquidity() throws IOException {
         BigDecimal allowedVolume = new BigDecimal(10001);
 
         tradingService.getLimitPrice(longExchange, currencyPair, allowedVolume, Order.OrderType.ASK);
@@ -255,7 +255,7 @@ public class TradingServiceTest extends BaseTestCase {
 
     // the exchange doesn't have enough volume to fill my gigantic order
     @Test(expected = RuntimeException.class)
-    public void testLimitPriceShortInsufficientLiquidity() {
+    public void testLimitPriceShortInsufficientLiquidity() throws IOException {
         BigDecimal allowedVolume = new BigDecimal(10001);
 
         tradingService.getLimitPrice(longExchange, currencyPair, allowedVolume, Order.OrderType.BID);


### PR DESCRIPTION
In cases where `getLimitPrice()` could not fetch the order book because of rate limiting (ie. 429 from the server) the resulting exception would not be caught properly and showed a message telling the user that the exchange did not have enough liquidity. This change improves the error handling so that we show more appropriate error messages when errors occur in this method.